### PR TITLE
Changes to image handling

### DIFF
--- a/src/AAListBox.cpp
+++ b/src/AAListBox.cpp
@@ -143,14 +143,14 @@ void guAAListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_ALBUMARTIST_PLAY,
                             wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play current selected album artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( Menu, ID_ALBUMARTIST_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add current selected tracks to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -159,21 +159,21 @@ void guAAListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMARTIST_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMARTIST_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMARTIST_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -188,7 +188,7 @@ void guAAListBox::CreateContextMenu( wxMenu * Menu ) const
             MenuItem = new wxMenuItem( Menu, ID_ALBUMARTIST_EDITTRACKS,
                                 wxString( _( "Edit Songs" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                                 _( "Edit the selected tracks" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu->Append( MenuItem );
         }
 
@@ -197,7 +197,7 @@ void guAAListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_ALBUMARTIST_SAVETOPLAYLIST,
                                 wxString( _( "Save to Playlist" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                                 _( "Save the selected tracks to Playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         if( ( ContextMenuFlags & guCONTEXTMENU_COPY_TO ) ||

--- a/src/AlListBox.cpp
+++ b/src/AlListBox.cpp
@@ -261,13 +261,13 @@ void guAlListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_ALBUM_PLAY,
                                 wxString( _( "Play" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                                 _( "Play current selected albums" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_ALBUM_ENQUEUE_AFTER_ALL,
                                 wxString( _( "Enqueue" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                                 _( "Add current selected albums to the Playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         Menu->Append( MenuItem );
 
         wxMenu * EnqueueMenu = new wxMenu();
@@ -275,19 +275,19 @@ void guAlListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUM_ENQUEUE_AFTER_TRACK,
                                 wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                                 _( "Add current selected albums to the Playlist as Next Tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUM_ENQUEUE_AFTER_ALBUM,
                                 wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                                 _( "Add current selected albums to the Playlist as Next Tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUM_ENQUEUE_AFTER_ARTIST,
                                 wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                                 _( "Add current selected albums to the Playlist as Next Tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         Menu->Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu, _( "Add the selected albums after" ) );
@@ -297,7 +297,7 @@ void guAlListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_ALBUM_EDITLABELS,
                                 wxString( _( "Edit Labels" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITLABELS ),
                                 _( "Edit the labels assigned to the selected albums" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tags ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tags ) );
         Menu->Append( MenuItem );
 
         if( ContextMenuFlags & guCONTEXTMENU_EDIT_TRACKS )
@@ -305,7 +305,7 @@ void guAlListBox::CreateContextMenu( wxMenu * Menu ) const
             MenuItem = new wxMenuItem( Menu, ID_ALBUM_EDITTRACKS,
                                 wxString( _( "Edit Songs" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                                 _( "Edit the selected songs" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu->Append( MenuItem );
         }
 
@@ -333,7 +333,7 @@ void guAlListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_ALBUM_SAVETOPLAYLIST,
                                 wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                                 _( "Save the selected tracks to Playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         if( SelCount == 1 && ( ContextMenuFlags & guCONTEXTMENU_DOWNLOAD_COVERS ) )
@@ -341,22 +341,22 @@ void guAlListBox::CreateContextMenu( wxMenu * Menu ) const
             Menu->AppendSeparator();
 
             MenuItem = new wxMenuItem( Menu, ID_ALBUM_MANUALCOVER, _( "Download Cover" ), _( "Download cover for the current selected album" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_download_covers ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_download_covers ) );
             Menu->Append( MenuItem );
 
             MenuItem = new wxMenuItem( Menu, ID_ALBUM_SELECT_COVER, _( "Select Cover" ), _( "Select the cover image file from disk" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_download_covers ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_download_covers ) );
             Menu->Append( MenuItem );
 
             MenuItem = new wxMenuItem( Menu, ID_ALBUM_COVER_DELETE, _( "Delete Cover" ), _( "Delete the cover for the selected album" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
             Menu->Append( MenuItem );
         }
 
         if( ContextMenuFlags & guCONTEXTMENU_EMBED_COVERS )
         {
             MenuItem = new wxMenuItem( Menu, ID_ALBUM_COVER_EMBED, _( "Embed Cover" ), _( "Embed the current cover to the album files" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
             Menu->Append( MenuItem );
         }
 

--- a/src/AlbumBrowser.cpp
+++ b/src/AlbumBrowser.cpp
@@ -301,11 +301,11 @@ void guAlbumBrowserItemPanel::OnContextMenu( wxContextMenuEvent &event )
         int ContextMenuFlags = m_AlbumBrowser->GetContextMenuFlags();
 
         MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_PLAY, _( "Play" ), _( "Play the album tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
         Menu.Append( MenuItem );
 
         MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_ENQUEUE_AFTER_ALL, _( "Enqueue" ), _( "Enqueue the album tracks to the playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         Menu.Append( MenuItem );
 
         wxMenu * EnqueueMenu = new wxMenu();
@@ -313,19 +313,19 @@ void guAlbumBrowserItemPanel::OnContextMenu( wxContextMenuEvent &event )
         MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMBROWSER_ENQUEUE_AFTER_TRACK,
                                 wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                                 _( "Add current selected tracks to playlist after the current track" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMBROWSER_ENQUEUE_AFTER_ALBUM,
                                 wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                                 _( "Add current selected tracks to playlist after the current album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMBROWSER_ENQUEUE_AFTER_ARTIST,
                                 wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                                 _( "Add current selected tracks to playlist after the current artist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         Menu.Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -333,24 +333,24 @@ void guAlbumBrowserItemPanel::OnContextMenu( wxContextMenuEvent &event )
         Menu.AppendSeparator();
 
         MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_EDITLABELS, _( "Edit Labels" ), _( "Edit the labels assigned to the selected albums" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tags ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tags ) );
         Menu.Append( MenuItem );
 
         if( ContextMenuFlags & guCONTEXTMENU_EDIT_TRACKS )
         {
             MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_EDITTRACKS, _( "Edit Songs" ), _( "Edit the selected songs" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu.Append( MenuItem );
         }
 
         Menu.AppendSeparator();
 
         MenuItem = new wxMenuItem( &Menu, ID_ALBUM_SELECTNAME, _( "Search Album" ), _( "Search the album in the library" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
         Menu.Append( MenuItem );
 
         MenuItem = new wxMenuItem( &Menu, ID_ARTIST_SELECTNAME, _( "Search Artist" ), _( "Search the artist in the library" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
         Menu.Append( MenuItem );
 
         if( ContextMenuFlags & guCONTEXTMENU_DOWNLOAD_COVERS )
@@ -358,22 +358,22 @@ void guAlbumBrowserItemPanel::OnContextMenu( wxContextMenuEvent &event )
             Menu.AppendSeparator();
 
             MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_SEARCHCOVER, _( "Download Cover" ), _( "Download cover for the current selected album" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_download_covers ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_download_covers ) );
             Menu.Append( MenuItem );
 
             MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_SELECTCOVER, _( "Select Cover" ), _( "Select the cover image file from disk" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_download_covers ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_download_covers ) );
             Menu.Append( MenuItem );
 
             MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_DELETECOVER, _( "Delete Cover" ), _( "Delete the cover for the selected album" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_delete ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_delete ) );
             Menu.Append( MenuItem );
         }
 
         if( ContextMenuFlags & guCONTEXTMENU_EMBED_COVERS )
         {
             MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_EMBEDCOVER, _( "Embed Cover" ), _( "Embed the cover to the selected album tracks" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_doc_save ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_doc_save ) );
             Menu.Append( MenuItem );
         }
 
@@ -416,7 +416,7 @@ void guAlbumBrowserItemPanel::OnContextMenu( wxContextMenuEvent &event )
         Menu.AppendSeparator();
 
         MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_COPYTOCLIPBOARD, _( "Copy to Clipboard" ), _( "Copy the album info to clipboard" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_copy ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ) );
         Menu.Append( MenuItem );
 
 
@@ -699,7 +699,7 @@ guAlbumBrowser::guAlbumBrowser( wxWindow * parent, guMediaViewer * mediaviewer )
     m_ItemStart = 0;
     m_LastItemStart = wxNOT_FOUND;
     m_ItemCount = 1;
-    m_BlankCD = new wxBitmap( guImage( guIMAGE_INDEX_no_cover ) );
+    m_BlankCD = new wxBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_no_cover ) );
     m_ConfigPath = mediaviewer->ConfigPath() + wxT( "/albumbrowser" );
     m_BigCoverShowed = false;
     m_BigCoverTracksContextMenu = false;
@@ -1581,7 +1581,7 @@ void guAlbumBrowser::OnBitmapClicked( guAlbumBrowserItem * albumitem, const wxPo
 
         if( !Image )
         {
-            Image = new wxImage( guImage( guIMAGE_INDEX_no_cover ) );
+            Image = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_no_cover ) );
         }
 
         guImageResize( Image, 300, true );
@@ -1697,7 +1697,7 @@ void guAlbumBrowser::AlbumCoverChanged( const int albumid )
 
         if( !Image )
         {
-            Image = new wxImage( guImage( guIMAGE_INDEX_no_cover ) );
+            Image = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_no_cover ) );
         }
 
         guImageResize( Image, 300, true );
@@ -1840,11 +1840,11 @@ void guAlbumBrowser::OnBigCoverContextMenu( wxContextMenuEvent &event )
     int ContextMenuFlags = m_MediaViewer->GetContextMenuFlags();
 
     MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_PLAY, _( "Play" ), _( "Play the album tracks" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu.Append( MenuItem );
 
     MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_ENQUEUE_AFTER_ALL, _( "Enqueue" ), _( "Enqueue the album tracks to the playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu.Append( MenuItem );
 
     wxMenu * EnqueueMenu = new wxMenu();
@@ -1852,19 +1852,19 @@ void guAlbumBrowser::OnBigCoverContextMenu( wxContextMenuEvent &event )
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMBROWSER_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMBROWSER_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMBROWSER_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     Menu.Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -1872,24 +1872,24 @@ void guAlbumBrowser::OnBigCoverContextMenu( wxContextMenuEvent &event )
     Menu.AppendSeparator();
 
     MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_EDITLABELS, _( "Edit Labels" ), _( "Edit the labels assigned to the selected albums" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tags ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tags ) );
     Menu.Append( MenuItem );
 
     if( ContextMenuFlags & guCONTEXTMENU_EDIT_TRACKS )
     {
         MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_EDITTRACKS, _( "Edit Songs" ), _( "Edit the selected songs" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
         Menu.Append( MenuItem );
     }
 
     Menu.AppendSeparator();
 
     MenuItem = new wxMenuItem( &Menu, ID_ALBUM_SELECTNAME, _( "Search Album" ), _( "Search the album in the library" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
     Menu.Append( MenuItem );
 
     MenuItem = new wxMenuItem( &Menu, ID_ARTIST_SELECTNAME, _( "Search Artist" ), _( "Search the artist in the library" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
     Menu.Append( MenuItem );
 
     if( ContextMenuFlags & guCONTEXTMENU_DOWNLOAD_COVERS )
@@ -1897,29 +1897,29 @@ void guAlbumBrowser::OnBigCoverContextMenu( wxContextMenuEvent &event )
         Menu.AppendSeparator();
 
         MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_SEARCHCOVER, _( "Download Cover" ), _( "Download cover for the current selected album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_download_covers ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_download_covers ) );
         Menu.Append( MenuItem );
 
         MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_SELECTCOVER, _( "Select Cover" ), _( "Select the cover image file from disk" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_download_covers ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_download_covers ) );
         Menu.Append( MenuItem );
 
         MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_DELETECOVER, _( "Delete Cover" ), _( "Delete the cover for the selected album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_delete ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_delete ) );
         Menu.Append( MenuItem );
     }
 
     if( ContextMenuFlags & guCONTEXTMENU_EMBED_COVERS )
     {
         MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_EMBEDCOVER, _( "Embed Cover" ), _( "Embed the cover to the selected album tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_doc_save ) );
         Menu.Append( MenuItem );
     }
 
     Menu.AppendSeparator();
 
     MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_COPYTOCLIPBOARD, _( "Copy to Clipboard" ), _( "Copy the album info to clipboard" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_copy ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ) );
     Menu.Append( MenuItem );
 
 
@@ -1975,11 +1975,11 @@ void guAlbumBrowser::OnBigCoverTracksContextMenu( wxContextMenuEvent &event )
     int ContextMenuFlags = m_MediaViewer->GetContextMenuFlags();
 
     MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_TRACKS_PLAY, _( "Play" ), _( "Play the album tracks" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu.Append( MenuItem );
 
     MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_TRACKS_ENQUEUE_AFTER_ALL, _( "Enqueue" ), _( "Enqueue the album tracks to the playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu.Append( MenuItem );
 
     wxMenu * EnqueueMenu = new wxMenu();
@@ -1987,19 +1987,19 @@ void guAlbumBrowser::OnBigCoverTracksContextMenu( wxContextMenuEvent &event )
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMBROWSER_TRACKS_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMBROWSER_TRACKS_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ALBUMBROWSER_TRACKS_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     Menu.Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -2007,13 +2007,13 @@ void guAlbumBrowser::OnBigCoverTracksContextMenu( wxContextMenuEvent &event )
     Menu.AppendSeparator();
 
     MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_TRACKS_EDITLABELS, _( "Edit Labels" ), _( "Edit the labels assigned to the selected albums" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tags ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tags ) );
     Menu.Append( MenuItem );
 
     if( ContextMenuFlags & guCONTEXTMENU_EDIT_TRACKS )
     {
         MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_TRACKS_EDITTRACKS, _( "Edit Songs" ), _( "Edit the selected songs" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
         Menu.Append( MenuItem );
     }
 
@@ -2022,7 +2022,7 @@ void guAlbumBrowser::OnBigCoverTracksContextMenu( wxContextMenuEvent &event )
     MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_TRACKS_PLAYLIST_SAVE,
                         wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                         _( "Save the selected tracks to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_doc_save ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_doc_save ) );
     Menu.Append( MenuItem );
 
     MenuItem = new wxMenuItem( &Menu, ID_ALBUMBROWSER_TRACKS_SMART_PLAYLIST, _( "Create Smart Playlist" ), _( "Create a smart playlist from this track" ) );

--- a/src/ArListBox.cpp
+++ b/src/ArListBox.cpp
@@ -145,14 +145,14 @@ void guArListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_ARTIST_PLAY,
                             wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play current selected artists" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( Menu, ID_ARTIST_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add current selected artists to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -161,21 +161,21 @@ void guArListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ARTIST_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ARTIST_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_ARTIST_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -188,7 +188,7 @@ void guArListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_ARTIST_EDITLABELS,
                             wxString( _( "Edit Labels" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITLABELS ),
                             _( "Edit the labels assigned to the selected artists" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tags ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tags ) );
         Menu->Append( MenuItem );
 
         if( ContextMenuFlags & guCONTEXTMENU_EDIT_TRACKS )
@@ -196,7 +196,7 @@ void guArListBox::CreateContextMenu( wxMenu * Menu ) const
             MenuItem = new wxMenuItem( Menu, ID_ARTIST_EDITTRACKS,
                             wxString( _( "Edit Songs" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                             _( "Edit the songs from the selected artists" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu->Append( MenuItem );
         }
 
@@ -205,7 +205,7 @@ void guArListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_ARTIST_SAVETOPLAYLIST,
                             wxString( _( "Save to Playlist" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                             _( "Save the selected tracks to playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         if( ( ContextMenuFlags & guCONTEXTMENU_COPY_TO ) ||

--- a/src/AuiDockArt.cpp
+++ b/src/AuiDockArt.cpp
@@ -54,8 +54,8 @@ wxString wxAuiChopText(wxDC& dc, const wxString& text, int max_size)
 // -------------------------------------------------------------------------------- //
 guAuiDockArt::guAuiDockArt() : wxAuiDefaultDockArt()
 {
-    m_CloseNormal = guImage( guIMAGE_INDEX_tiny_close_normal );
-    m_CloseHighLight = guImage( guIMAGE_INDEX_tiny_close_highlight );
+    m_CloseNormal = guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_close_normal );
+    m_CloseHighLight = guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_close_highlight );
 }
 
 // -------------------------------------------------------------------------------- //

--- a/src/AuiNotebook.cpp
+++ b/src/AuiNotebook.cpp
@@ -96,8 +96,8 @@ guAuiTabArt::guAuiTabArt() : wxAuiDefaultTabArt()
     m_TextFgColor = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT );
     m_SelTextFgColour = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT );
 
-    m_disabledCloseBmp = guImage( guIMAGE_INDEX_tiny_close_normal );
-    m_activeCloseBmp = guImage( guIMAGE_INDEX_tiny_close_highlight );
+    m_disabledCloseBmp = guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_close_normal );
+    m_activeCloseBmp = guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_close_highlight );
 }
 
 // -------------------------------------------------------------------------------- //

--- a/src/ChannelEditor.cpp
+++ b/src/ChannelEditor.cpp
@@ -80,7 +80,7 @@ guChannelEditor::guChannelEditor( wxWindow * parent, guPodcastChannel * channel 
         }
         else
         {
-            m_Image->SetBitmap( guBitmap( guIMAGE_INDEX_mid_podcast ) );
+            m_Image->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_mid_podcast ) );
             if( !channel->m_Image.IsEmpty() )
             {
                 guChannelUpdateImageThread * UpdateImageThread = new guChannelUpdateImageThread( this, channel->m_Image.c_str() );

--- a/src/CoListBox.cpp
+++ b/src/CoListBox.cpp
@@ -101,14 +101,14 @@ void guCoListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_COMPOSER_PLAY,
                             wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play current selected composer" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( Menu, ID_COMPOSER_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add current selected tracks to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -117,21 +117,21 @@ void guCoListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( EnqueueMenu, ID_COMPOSER_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected albums to the Playlist as Next Tracks" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_COMPOSER_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected albums to the Playlist as Next Tracks" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_COMPOSER_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected albums to the Playlist as Next Tracks" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -146,7 +146,7 @@ void guCoListBox::CreateContextMenu( wxMenu * Menu ) const
             MenuItem = new wxMenuItem( Menu, ID_COMPOSER_EDITTRACKS,
                                     wxString( _( "Edit songs" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                                     _( "Edit the selected tracks" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu->Append( MenuItem );
         }
 
@@ -155,7 +155,7 @@ void guCoListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_COMPOSER_SAVETOPLAYLIST,
                                 wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                                 _( "Save the selected tracks to playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         if( ContextMenuFlags & guCONTEXTMENU_COPY_TO )

--- a/src/ConfirmExit.cpp
+++ b/src/ConfirmExit.cpp
@@ -32,7 +32,7 @@ guExitConfirmDlg::guExitConfirmDlg( wxWindow * parent ) :
 
 	wxBoxSizer * TopSizer = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticBitmap * ExitBitmap = new wxStaticBitmap( this, wxID_ANY, guImage( guIMAGE_INDEX_exit ), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticBitmap * ExitBitmap = new wxStaticBitmap( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_exit ), wxDefaultPosition, wxDefaultSize, 0 );
 	TopSizer->Add( ExitBitmap, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
     wxStaticText * MessageString = new wxStaticText( this, wxID_ANY, _("Are you sure you want to exit the application?"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/CopyTo.cpp
+++ b/src/CopyTo.cpp
@@ -885,7 +885,7 @@ guCopyToThread::ExitCode guCopyToThread::Entry()
                         FileCounter,
                         SizeToString( m_SizeCounter ).c_str(),
                         LenToString( TimeCounter * 1000 ).c_str() );
-                    wxImage IconImg = guImage( guIMAGE_INDEX_guayadeque );
+                    wxImage IconImg = guNS_Image::GetImage( guIMAGE_INDEX_guayadeque );
                     NotifySrv->Notify( wxEmptyString, _( "Finished copying files" ), FinishMsg, &IconImg );
                 }
                 //

--- a/src/CoverEdit.cpp
+++ b/src/CoverEdit.cpp
@@ -107,18 +107,18 @@ guCoverEditor::guCoverEditor( wxWindow* parent, const wxString &Artist, const wx
 
     CoverSizer->Add( 0, 0, 1, wxEXPAND, 5 );
 
-    m_PrevButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_left ), wxDefaultPosition, wxSize( 32, 96 ), wxBU_AUTODRAW );
+    m_PrevButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_left ), wxDefaultPosition, wxSize( 32, 96 ), wxBU_AUTODRAW );
     CoverSizer->Add( m_PrevButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
     int CoverFrame = Config->ReadNum( wxT( "CoverFrame" ), guCOVERFRAME_DEFAULT, wxT( "general" ) );
-    wxImage DefaultCover( guImage( CoverFrame ? guIMAGE_INDEX_blank_cd_cover : guIMAGE_INDEX_no_cover ) );
+    wxImage DefaultCover( guNS_Image::GetImage( CoverFrame ? guIMAGE_INDEX_blank_cd_cover : guIMAGE_INDEX_no_cover ) );
     
     if( !CoverFrame ) DefaultCover.Rescale( 250, 250, wxIMAGE_QUALITY_HIGH );
 
     m_CoverBitmap = new wxStaticBitmap( this, wxID_ANY, DefaultCover, wxDefaultPosition, wxSize( -1,-1 ), 0 );
     CoverSizer->Add( m_CoverBitmap, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5 );
 
-    m_NextButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_right ), wxDefaultPosition, wxSize( 32, 96 ), wxBU_AUTODRAW );
+    m_NextButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_right ), wxDefaultPosition, wxSize( 32, 96 ), wxBU_AUTODRAW );
     CoverSizer->Add( m_NextButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
 
@@ -365,7 +365,7 @@ void guCoverEditor::UpdateCoverBitmap( void )
     int CoverFrame = Config->ReadNum( wxT( "CoverFrame" ), guCOVERFRAME_DEFAULT, wxT( "general" ) );
     if( CoverFrame == guCOVERFRAME_DEFAULT )
     {
-        wxBitmap * BlankCD = new wxBitmap( guImage( guIMAGE_INDEX_blank_cd_cover ) );
+        wxBitmap * BlankCD = new wxBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_blank_cd_cover ) );
         if( BlankCD )
         {
             if( BlankCD->IsOk() )
@@ -403,7 +403,7 @@ void guCoverEditor::UpdateCoverBitmap( void )
         }
         else
         {
-            CoverImage = guImage( guIMAGE_INDEX_no_cover );
+            CoverImage = guNS_Image::GetImage( guIMAGE_INDEX_no_cover );
             m_SizeStaticText->SetLabel( wxEmptyString );
         }
         CoverImage.Rescale( 250, 250, wxIMAGE_QUALITY_HIGH );

--- a/src/CoverFrame.cpp
+++ b/src/CoverFrame.cpp
@@ -106,15 +106,15 @@ void guCoverFrame::SetBitmap( const guSongCoverType CoverType, const wxString &C
     }
     else if( CoverType == GU_SONGCOVER_NONE )
     {
-        CoverImage = guImage( guIMAGE_INDEX_no_cover );
+        CoverImage = guNS_Image::GetImage( guIMAGE_INDEX_no_cover );
     }
     else if( CoverType == GU_SONGCOVER_RADIO )
     {
-        CoverImage = guImage( guIMAGE_INDEX_net_radio );
+        CoverImage = guNS_Image::GetImage( guIMAGE_INDEX_net_radio );
     }
     else if( CoverType == GU_SONGCOVER_PODCAST )
     {
-        CoverImage = guImage( guIMAGE_INDEX_podcast );
+        CoverImage = guNS_Image::GetImage( guIMAGE_INDEX_podcast );
     }
     //
     if( CoverImage.IsOk() )
@@ -123,7 +123,7 @@ void guCoverFrame::SetBitmap( const guSongCoverType CoverType, const wxString &C
         int CoverFrame = Config->ReadNum( wxT( "CoverFrame" ), guCOVERFRAME_DEFAULT, wxT( "general" ) );
         if( CoverFrame == guCOVERFRAME_DEFAULT )
         {
-            wxBitmap * BlankCD = new wxBitmap( guImage( guIMAGE_INDEX_blank_cd_cover ) );
+            wxBitmap * BlankCD = new wxBitmap( guNS_Image::GetImage( guIMAGE_INDEX_blank_cd_cover ) );
             if( BlankCD )
             {
                 if( BlankCD->IsOk() )

--- a/src/CoverPanel.cpp
+++ b/src/CoverPanel.cpp
@@ -103,11 +103,11 @@ void guCoverPanel::UpdateImage( void )
             break;
 
         case GU_SONGCOVER_RADIO :
-            CoverImage = new wxImage( guImage( guIMAGE_INDEX_net_radio ) );
+            CoverImage = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_net_radio ) );
             break;
 
         case GU_SONGCOVER_PODCAST :
-            CoverImage = new wxImage( guImage( guIMAGE_INDEX_podcast ) );
+            CoverImage = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_podcast ) );
             break;
 
         default :
@@ -116,7 +116,7 @@ void guCoverPanel::UpdateImage( void )
 
     if( !CoverImage )
     {
-        CoverImage = new wxImage( guImage( guIMAGE_INDEX_no_cover ) );
+        CoverImage = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_no_cover ) );
     }
 
     if( CoverImage )

--- a/src/DynamicPlayList.cpp
+++ b/src/DynamicPlayList.cpp
@@ -525,15 +525,15 @@ guDynPlayListEditor::guDynPlayListEditor( wxWindow * parent, guDynPlayList * pla
     m_LengthSeconds->Show( false );
 	m_FilterEditSizer->Add( m_LengthSeconds, 1, wxBOTTOM|wxRIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 
-	m_FilterAdd = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_FilterAdd = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_FilterAdd->Enable( false );
 	m_FilterEditSizer->Add( m_FilterAdd, 0, wxALIGN_CENTER_VERTICAL|wxBOTTOM, 5 );
 
-	m_FilterDel = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_FilterDel = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_FilterDel->Enable( false );
 	m_FilterEditSizer->Add( m_FilterDel, 0, wxALIGN_CENTER_VERTICAL|wxBOTTOM|wxLEFT, 5 );
 
-	m_FilterAccept = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_FilterAccept = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_FilterAccept->Enable( false );
 	m_FilterEditSizer->Add( m_FilterAccept, 0, wxALIGN_CENTER_VERTICAL|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 

--- a/src/Equalizer.cpp
+++ b/src/Equalizer.cpp
@@ -125,17 +125,17 @@ guEq10Band::guEq10Band( wxWindow * parent, guMediaCtrl * mediactrl ) //wxDialog(
 	}
 	TopSizer->Add( m_PresetComboBox, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
 
-	m_SaveButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_doc_save ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_SaveButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_SaveButton->Enable( false );
 
 	TopSizer->Add( m_SaveButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
 
-	m_DelButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_clear ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_DelButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_DelButton->Enable( false );
 
 	TopSizer->Add( m_DelButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
 
-	m_ResetButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_reload ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_ResetButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_reload ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	TopSizer->Add( m_ResetButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
 
 	MainSizer->Add( TopSizer, 0, wxEXPAND, 5 );

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -83,9 +83,9 @@ guGenericDirCtrl::guGenericDirCtrl( wxWindow * parent, guMainFrame * mainframe, 
     m_ShowPaths = showpaths;
     m_FileBrowserDirCtrl = ( guFileBrowserDirCtrl * ) parent;
     wxImageList * ImageList = GetTreeCtrl()->GetImageList();
-    ImageList->Add( guImage( guIMAGE_INDEX_tiny_library ) );
-    ImageList->Add( guImage( guIMAGE_INDEX_tiny_podcast ) );
-    ImageList->Add( guImage( guIMAGE_INDEX_tiny_record ) );
+    ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_tiny_library ) );
+    ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_tiny_podcast ) );
+    ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_tiny_record ) );
 
     guConfig * Config = ( guConfig * ) guConfig::Get();
     Config->RegisterObject( this );
@@ -207,34 +207,34 @@ guFileBrowserDirCtrl::guFileBrowserDirCtrl( wxWindow * parent, guMainFrame * mai
     guConfig * Config = ( guConfig * ) guConfig::Get();
     Config->RegisterObject( this );
 
-	wxBoxSizer * MainSizer;
-	MainSizer = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer * MainSizer;
+    MainSizer = new wxBoxSizer( wxVERTICAL );
 
     int ShowPaths = Config->ReadNum( wxT( "ShowLibPaths" ), guFILEBROWSER_SHOWPATH_LOCATIONS, wxT( "filebrowser" ) );
-	m_DirCtrl = new guGenericDirCtrl( this, m_MainFrame, ShowPaths );
-	m_DirCtrl->ShowHidden( false );
-	SetPath( dirpath, FindMediaViewerByPath( m_MainFrame, dirpath ) );
-	MainSizer->Add( m_DirCtrl, 1, wxEXPAND, 5 );
+    m_DirCtrl = new guGenericDirCtrl( this, m_MainFrame, ShowPaths );
+    m_DirCtrl->ShowHidden( false );
+    SetPath( dirpath, FindMediaViewerByPath( m_MainFrame, dirpath ) );
+    MainSizer->Add( m_DirCtrl, 1, wxEXPAND, 5 );
 
-	wxBoxSizer * DirBtnSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer * DirBtnSizer = new wxBoxSizer( wxHORIZONTAL );
 
 
-	DirBtnSizer->Add( 0, 0, 1, wxEXPAND, 5 );
+    DirBtnSizer->Add( 0, 0, 1, wxEXPAND, 5 );
 
-	m_ShowLibPathsBtn = new wxBitmapToggleButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_library ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_ShowLibPathsBtn = new wxBitmapToggleButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_library ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_ShowLibPathsBtn->SetToolTip( ShowPaths == guFILEBROWSER_SHOWPATH_SYSTEM ?
                           _( "See used locations" ) :
                           _( "See system files" ) );
-	m_ShowLibPathsBtn->SetValue( ShowPaths & guFILEBROWSER_SHOWPATH_LOCATIONS );
-	DirBtnSizer->Add( m_ShowLibPathsBtn, 0, wxTOP|wxBOTTOM|wxRIGHT, 5 );
+    m_ShowLibPathsBtn->SetValue( ShowPaths & guFILEBROWSER_SHOWPATH_LOCATIONS );
+    DirBtnSizer->Add( m_ShowLibPathsBtn, 0, wxTOP|wxBOTTOM|wxRIGHT, 5 );
 
-	MainSizer->Add( DirBtnSizer, 0, wxEXPAND, 5 );
+    MainSizer->Add( DirBtnSizer, 0, wxEXPAND, 5 );
 
-	this->SetSizer( MainSizer );
-	this->Layout();
+    this->SetSizer( MainSizer );
+    this->Layout();
 
     m_DirCtrl->Connect( wxEVT_COMMAND_TREE_ITEM_MENU, wxTreeEventHandler( guFileBrowserDirCtrl::OnContextMenu ), NULL, this );
-	m_ShowLibPathsBtn->Connect( wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler( guFileBrowserDirCtrl::OnShowLibPathsClick ), NULL, this );
+    m_ShowLibPathsBtn->Connect( wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler( guFileBrowserDirCtrl::OnShowLibPathsClick ), NULL, this );
 
     Connect( ID_CONFIG_UPDATED, guConfigUpdatedEvent, wxCommandEventHandler( guFileBrowserDirCtrl::OnConfigUpdated ), NULL, this );
 
@@ -249,7 +249,7 @@ guFileBrowserDirCtrl::~guFileBrowserDirCtrl()
 
     Config->WriteNum( wxT( "ShowLibPaths" ), m_ShowLibPathsBtn->GetValue(), wxT( "filebrowser" ) );
     m_DirCtrl->Disconnect( wxEVT_COMMAND_TREE_ITEM_MENU, wxTreeEventHandler( guFileBrowserDirCtrl::OnContextMenu ), NULL, this );
-	m_ShowLibPathsBtn->Disconnect( wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler( guFileBrowserDirCtrl::OnShowLibPathsClick ), NULL, this );
+    m_ShowLibPathsBtn->Disconnect( wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler( guFileBrowserDirCtrl::OnShowLibPathsClick ), NULL, this );
 
     Disconnect( ID_CONFIG_UPDATED, guConfigUpdatedEvent, wxCommandEventHandler( guFileBrowserDirCtrl::OnConfigUpdated ), NULL, this );
 }
@@ -338,13 +338,13 @@ void guFileBrowserDirCtrl::OnContextMenu( wxTreeEvent &event )
     MenuItem = new wxMenuItem( &Menu, ID_FILESYSTEM_FOLDER_PLAY,
                             wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play the selected folder" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu.Append( MenuItem );
 
     MenuItem = new wxMenuItem( &Menu, ID_FILESYSTEM_FOLDER_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add the selected folder to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu.Append( MenuItem );
 
     wxMenu * EnqueueMenu = new wxMenu();
@@ -352,19 +352,19 @@ void guFileBrowserDirCtrl::OnContextMenu( wxTreeEvent &event )
     MenuItem = new wxMenuItem( EnqueueMenu, ID_FILESYSTEM_FOLDER_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_FILESYSTEM_FOLDER_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_FILESYSTEM_FOLDER_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     Menu.Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -374,7 +374,7 @@ void guFileBrowserDirCtrl::OnContextMenu( wxTreeEvent &event )
     MenuItem = new wxMenuItem( &Menu, ID_FILESYSTEM_FOLDER_EDITTRACKS,
                             wxString( _( "Edit Tracks" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                             _( "Edit the tracks in the selected folder" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
     Menu.Append( MenuItem );
 
     Menu.AppendSeparator();
@@ -382,7 +382,7 @@ void guFileBrowserDirCtrl::OnContextMenu( wxTreeEvent &event )
     MenuItem = new wxMenuItem( &Menu, ID_FILESYSTEM_FOLDER_SAVEPLAYLIST,
                             wxString( _( "Save to Playlist" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                             _( "Add the tracks in the selected folder to a playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
     Menu.Append( MenuItem );
 
     Menu.AppendSeparator();
@@ -390,7 +390,7 @@ void guFileBrowserDirCtrl::OnContextMenu( wxTreeEvent &event )
     MenuItem = new wxMenuItem( &Menu, ID_FILESYSTEM_FOLDER_COPY,
                             _( "Copy" ),
                             _( "Copy the selected folder to clipboard" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_copy ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ) );
     Menu.Append( MenuItem );
     //MenuItem->Enable( false );
 
@@ -415,11 +415,11 @@ void guFileBrowserDirCtrl::OnContextMenu( wxTreeEvent &event )
     Menu.Append( MenuItem );
 
     MenuItem = new wxMenuItem( &Menu, ID_FILESYSTEM_FOLDER_RENAME, _( "Rename" ), _( "Rename the selected folder" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
     Menu.Append( MenuItem );
 
     MenuItem = new wxMenuItem( &Menu, ID_FILESYSTEM_FOLDER_DELETE, _( "Remove" ), _( "Remove the selected folder" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
     Menu.Append( MenuItem );
 
     Menu.AppendSeparator();
@@ -1111,13 +1111,13 @@ void guFilesListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_FILESYSTEM_ITEMS_PLAY,
                             wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play current selected files" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_FILESYSTEM_ITEMS_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add current selected files to playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         Menu->Append( MenuItem );
 
         wxMenu * EnqueueMenu = new wxMenu();
@@ -1125,21 +1125,21 @@ void guFilesListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( EnqueueMenu, ID_FILESYSTEM_ITEMS_ENQUEUE_AFTER_TRACK,
                                 wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                                 _( "Add current selected tracks to playlist after the current track" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
         MenuItem->Enable( SelCount );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_FILESYSTEM_ITEMS_ENQUEUE_AFTER_ALBUM,
                                 wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                                 _( "Add current selected tracks to playlist after the current album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
         MenuItem->Enable( SelCount );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_FILESYSTEM_ITEMS_ENQUEUE_AFTER_ARTIST,
                                 wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                                 _( "Add current selected tracks to playlist after the current artist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
         MenuItem->Enable( SelCount );
 
@@ -1153,7 +1153,7 @@ void guFilesListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_FILESYSTEM_ITEMS_EDITTRACKS,
                             wxString( _( "Edit Tracks" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                             _( "Edit the current selected files" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
         Menu->Append( MenuItem );
 
         Menu->AppendSeparator();
@@ -1161,14 +1161,14 @@ void guFilesListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_FILESYSTEM_ITEMS_SAVEPLAYLIST,
                             wxString( _( "Save to Playlist" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                             _( "Add the current selected tracks to a playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
     }
 
     Menu->AppendSeparator();
 
     MenuItem = new wxMenuItem( Menu, ID_FILESYSTEM_ITEMS_COPY, _( "Copy" ), _( "Copy the selected folder to clipboard" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_copy ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ) );
     Menu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( Menu, ID_FILESYSTEM_ITEMS_PASTE, _( "Paste" ), _( "Paste to the selected dir" ) );
@@ -1189,11 +1189,11 @@ void guFilesListBox::CreateContextMenu( wxMenu * Menu ) const
         Menu->AppendSeparator();
 
         MenuItem = new wxMenuItem( Menu, ID_FILESYSTEM_ITEMS_RENAME, _( "Rename Files" ), _( "Rename the current selected file" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_FILESYSTEM_ITEMS_DELETE, _( "Remove" ), _( "Delete the selected files" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
         Menu->Append( MenuItem );
 
         Menu->AppendSeparator();

--- a/src/FileRenamer.cpp
+++ b/src/FileRenamer.cpp
@@ -82,10 +82,10 @@ guFileRenamer::guFileRenamer( wxWindow * parent, guDbLibrary * db, const wxArray
 
 	PatternSizer->Add( m_PatTextCtrl, 1, wxTOP|wxBOTTOM|wxRIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 
-	m_PatApplyBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_PatApplyBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	PatternSizer->Add( m_PatApplyBtn, 0, wxTOP|wxBOTTOM|wxRIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 
-	m_PatRevertBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_reload ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_PatRevertBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_reload ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	PatternSizer->Add( m_PatRevertBtn, 0, wxTOP|wxBOTTOM|wxRIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 
 	EditSizer->Add( PatternSizer, 1, wxEXPAND, 5 );

--- a/src/GeListBox.cpp
+++ b/src/GeListBox.cpp
@@ -90,14 +90,14 @@ void guGeListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_GENRE_PLAY,
                         wxString( _( "Play" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                         _( "Play current selected genres" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( Menu, ID_GENRE_ENQUEUE_AFTER_ALL,
                         wxString( _( "Enqueue" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                         _( "Add current selected genres to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_add ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -106,21 +106,21 @@ void guGeListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( EnqueueMenu, ID_GENRE_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_GENRE_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_GENRE_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -133,7 +133,7 @@ void guGeListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_GENRE_SAVETOPLAYLIST,
                             wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                             _( "Save the selected tracks to playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_doc_save ) );
         Menu->Append( MenuItem );
 
         if( m_LibPanel->GetContextMenuFlags() & guCONTEXTMENU_COPY_TO )

--- a/src/Images.cpp
+++ b/src/Images.cpp
@@ -19,360 +19,365 @@
 // -------------------------------------------------------------------------------- //
 #include "Images.h"
 
-#include <wx/mstream.h>
+#include <map>
+// -------------------------------------------------------------------------------- //
+#include "images/add.h"
+#include "images/blank_cd_cover.h"
+#include "images/bookmark.h"
+#include "images/default_lastfm_image.h"
+#include "images/del.h"
+#include "images/doc_new.h"
+#include "images/doc_save.h"
+#include "images/download_covers.h"
+#include "images/down.h"
+#include "images/edit_clear.h"
+#include "images/edit_copy.h"
+#include "images/edit_delete.h"
+#include "images/edit.h"
+#include "images/exit.h"
+#include "images/filter.h"
+#include "images/guayadeque.h"
+#include "images/guayadeque_taskbar.h"
+#include "images/lastfm_as_off.h"
+#include "images/lastfm_as_on.h"
+#include "images/lastfm_on.h"
+#include "images/left.h"
+#include "images/musicbrainz.h"
+#include "images/net_radio.h"
+#include "images/no_cover.h"
+#include "images/no_photo.h"
+#include "images/numerate.h"
+#include "images/podcast.h"
+#include "images/right.h"
+#include "images/search_engine.h"
+#include "images/search.h"
+#include "images/splash.h"
+#include "images/system_run.h"
+#include "images/tags.h"
+#include "images/tiny_accept.h"
+#include "images/tiny_add.h"
+#include "images/tiny_del.h"
+#include "images/tiny_doc_save.h"
+#include "images/tiny_edit_clear.h"
+#include "images/tiny_edit.h"
+#include "images/tiny_edit_copy.h"
+#include "images/tiny_filter.h"
+#include "images/tiny_left.h"
+#include "images/tiny_net_radio.h"
+#include "images/tiny_numerate.h"
+#include "images/mid_podcast.h"
+#include "images/tiny_podcast.h"
+#include "images/tiny_reload.h"
+#include "images/tiny_right.h"
+#include "images/tiny_search.h"
+#include "images/tiny_search_again.h"
+#include "images/tiny_search_engine.h"
+#include "images/tiny_shoutcast.h"
+#include "images/tiny_tunein.h"
+#include "images/tiny_status_error.h"
+#include "images/tiny_status_pending.h"
+#include "images/track.h"
+#include "images/up.h"
+#include "images/tiny_library.h"
+#include "images/tiny_record.h"
+#include "images/pref_commands.h"
+#include "images/pref_copy_to.h"
+#include "images/pref_general.h"
+#include "images/pref_last_fm.h"
+#include "images/pref_library.h"
+#include "images/pref_links.h"
+#include "images/pref_lyrics.h"
+#include "images/pref_online_services.h"
+#include "images/pref_playback.h"
+#include "images/pref_podcasts.h"
+#include "images/pref_record.h"
+#include "images/pref_crossfader.h"
+#include "images/pref_jamendo.h"
+#include "images/pref_magnatune.h"
+#include "images/pref_accelerators.h"
+//
+#include "images/loc_library.h"
+#include "images/loc_portable_device.h"
+#include "images/loc_net_radio.h"
+#include "images/loc_podcast.h"
+#include "images/loc_magnatune.h"
+#include "images/loc_jamendo.h"
+#include "images/loc_lastfm.h"
+#include "images/loc_lyrics.h"
+//
+#include "images/tiny_close_normal.h"
+#include "images/tiny_close_highlight.h"
+//
+#include "images/player_highlight_equalizer.h"
+#include "images/player_highlight_muted.h"
+#include "images/player_highlight_next.h"
+#include "images/player_highlight_pause.h"
+#include "images/player_highlight_play.h"
+#include "images/player_highlight_prev.h"
+#include "images/player_highlight_random.h"
+#include "images/player_highlight_record.h"
+#include "images/player_highlight_repeat.h"
+#include "images/player_highlight_repeat_single.h"
+#include "images/player_highlight_search.h"
+#include "images/player_highlight_setup.h"
+#include "images/player_highlight_smart.h"
+#include "images/player_highlight_stop.h"
+#include "images/player_highlight_vol_hi.h"
+#include "images/player_highlight_vol_low.h"
+#include "images/player_highlight_vol_mid.h"
+#include "images/player_highlight_love.h"
+#include "images/player_highlight_ban.h"
+#include "images/player_light_equalizer.h"
+#include "images/player_light_muted.h"
+#include "images/player_light_next.h"
+#include "images/player_light_pause.h"
+#include "images/player_light_play.h"
+#include "images/player_light_prev.h"
+#include "images/player_light_random.h"
+#include "images/player_light_record.h"
+#include "images/player_light_repeat.h"
+#include "images/player_light_repeat_single.h"
+#include "images/player_light_search.h"
+#include "images/player_light_setup.h"
+#include "images/player_light_smart.h"
+#include "images/player_light_stop.h"
+#include "images/player_light_vol_hi.h"
+#include "images/player_light_vol_low.h"
+#include "images/player_light_vol_mid.h"
+#include "images/player_light_love.h"
+#include "images/player_light_ban.h"
+#include "images/player_normal_equalizer.h"
+#include "images/player_normal_muted.h"
+#include "images/player_normal_next.h"
+#include "images/player_normal_pause.h"
+#include "images/player_normal_play.h"
+#include "images/player_normal_prev.h"
+#include "images/player_normal_random.h"
+#include "images/player_normal_record.h"
+#include "images/player_normal_repeat.h"
+#include "images/player_normal_repeat_single.h"
+#include "images/player_normal_search.h"
+#include "images/player_normal_setup.h"
+#include "images/player_normal_smart.h"
+#include "images/player_normal_stop.h"
+#include "images/player_normal_vol_hi.h"
+#include "images/player_normal_vol_low.h"
+#include "images/player_normal_vol_mid.h"
+#include "images/player_normal_love.h"
+#include "images/player_normal_ban.h"
+#include "images/player_tiny_light_play.h"
+#include "images/player_tiny_light_stop.h"
+#include "images/player_tiny_red_stop.h"
+//
+#include "images/star_normal_tiny.h"
+#include "images/star_normal_mid.h"
+#include "images/star_normal_big.h"
+#include "images/star_highlight_tiny.h"
+#include "images/star_highlight_mid.h"
+#include "images/star_highlight_big.h"
+//
+#include "images/tiny_crossfade.h"
+#include "images/tiny_gapless.h"
+//
+#include "images/tiny_mv_library.h"
+#include "images/tiny_mv_albumbrowser.h"
+#include "images/tiny_mv_treeview.h"
+#include "images/tiny_mv_playlists.h"
 
 // -------------------------------------------------------------------------------- //
-#include "./images/add.h"
-#include "./images/blank_cd_cover.h"
-#include "./images/bookmark.h"
-#include "./images/default_lastfm_image.h"
-#include "./images/del.h"
-#include "./images/doc_new.h"
-#include "./images/doc_save.h"
-#include "./images/download_covers.h"
-#include "./images/down.h"
-#include "./images/edit_clear.h"
-#include "./images/edit_copy.h"
-#include "./images/edit_delete.h"
-#include "./images/edit.h"
-#include "./images/exit.h"
-#include "./images/filter.h"
-#include "./images/guayadeque.h"
-#include "./images/guayadeque_taskbar.h"
-#include "./images/lastfm_as_off.h"
-#include "./images/lastfm_as_on.h"
-#include "./images/lastfm_on.h"
-#include "./images/left.h"
-#include "./images/musicbrainz.h"
-#include "./images/net_radio.h"
-#include "./images/no_cover.h"
-#include "./images/no_photo.h"
-#include "./images/numerate.h"
-#include "./images/podcast.h"
-#include "./images/right.h"
-#include "./images/search_engine.h"
-#include "./images/search.h"
-#include "./images/splash.h"
-#include "./images/system_run.h"
-#include "./images/tags.h"
-#include "./images/tiny_accept.h"
-#include "./images/tiny_add.h"
-#include "./images/tiny_del.h"
-#include "./images/tiny_doc_save.h"
-#include "./images/tiny_edit_clear.h"
-#include "./images/tiny_edit.h"
-#include "./images/tiny_edit_copy.h"
-#include "./images/tiny_filter.h"
-#include "./images/tiny_left.h"
-#include "./images/tiny_net_radio.h"
-#include "./images/tiny_numerate.h"
-#include "./images/mid_podcast.h"
-#include "./images/tiny_podcast.h"
-#include "./images/tiny_reload.h"
-#include "./images/tiny_right.h"
-#include "./images/tiny_search.h"
-#include "./images/tiny_search_again.h"
-#include "./images/tiny_search_engine.h"
-#include "./images/tiny_shoutcast.h"
-#include "./images/tiny_tunein.h"
-#include "./images/tiny_status_error.h"
-#include "./images/tiny_status_pending.h"
-#include "./images/track.h"
-#include "./images/up.h"
-#include "./images/tiny_library.h"
-#include "./images/tiny_record.h"
-#include "./images/pref_commands.h"
-#include "./images/pref_copy_to.h"
-#include "./images/pref_general.h"
-#include "./images/pref_last_fm.h"
-#include "./images/pref_library.h"
-#include "./images/pref_links.h"
-#include "./images/pref_lyrics.h"
-#include "./images/pref_online_services.h"
-#include "./images/pref_playback.h"
-#include "./images/pref_podcasts.h"
-#include "./images/pref_record.h"
-#include "./images/pref_crossfader.h"
-#include "./images/pref_jamendo.h"
-#include "./images/pref_magnatune.h"
-#include "./images/pref_accelerators.h"
-//
-#include "./images/loc_library.h"
-#include "./images/loc_portable_device.h"
-#include "./images/loc_net_radio.h"
-#include "./images/loc_podcast.h"
-#include "./images/loc_magnatune.h"
-#include "./images/loc_jamendo.h"
-#include "./images/loc_lastfm.h"
-#include "./images/loc_lyrics.h"
-//
-#include "./images/tiny_close_normal.h"
-#include "./images/tiny_close_highlight.h"
-//
-#include "./images/player_highlight_equalizer.h"
-#include "./images/player_highlight_muted.h"
-#include "./images/player_highlight_next.h"
-#include "./images/player_highlight_pause.h"
-#include "./images/player_highlight_play.h"
-#include "./images/player_highlight_prev.h"
-#include "./images/player_highlight_random.h"
-#include "./images/player_highlight_record.h"
-#include "./images/player_highlight_repeat.h"
-#include "./images/player_highlight_repeat_single.h"
-#include "./images/player_highlight_search.h"
-#include "./images/player_highlight_setup.h"
-#include "./images/player_highlight_smart.h"
-#include "./images/player_highlight_stop.h"
-#include "./images/player_highlight_vol_hi.h"
-#include "./images/player_highlight_vol_low.h"
-#include "./images/player_highlight_vol_mid.h"
-#include "./images/player_highlight_love.h"
-#include "./images/player_highlight_ban.h"
-#include "./images/player_light_equalizer.h"
-#include "./images/player_light_muted.h"
-#include "./images/player_light_next.h"
-#include "./images/player_light_pause.h"
-#include "./images/player_light_play.h"
-#include "./images/player_light_prev.h"
-#include "./images/player_light_random.h"
-#include "./images/player_light_record.h"
-#include "./images/player_light_repeat.h"
-#include "./images/player_light_repeat_single.h"
-#include "./images/player_light_search.h"
-#include "./images/player_light_setup.h"
-#include "./images/player_light_smart.h"
-#include "./images/player_light_stop.h"
-#include "./images/player_light_vol_hi.h"
-#include "./images/player_light_vol_low.h"
-#include "./images/player_light_vol_mid.h"
-#include "./images/player_light_love.h"
-#include "./images/player_light_ban.h"
-#include "./images/player_normal_equalizer.h"
-#include "./images/player_normal_muted.h"
-#include "./images/player_normal_next.h"
-#include "./images/player_normal_pause.h"
-#include "./images/player_normal_play.h"
-#include "./images/player_normal_prev.h"
-#include "./images/player_normal_random.h"
-#include "./images/player_normal_record.h"
-#include "./images/player_normal_repeat.h"
-#include "./images/player_normal_repeat_single.h"
-#include "./images/player_normal_search.h"
-#include "./images/player_normal_setup.h"
-#include "./images/player_normal_smart.h"
-#include "./images/player_normal_stop.h"
-#include "./images/player_normal_vol_hi.h"
-#include "./images/player_normal_vol_low.h"
-#include "./images/player_normal_vol_mid.h"
-#include "./images/player_normal_love.h"
-#include "./images/player_normal_ban.h"
-#include "./images/player_tiny_light_play.h"
-#include "./images/player_tiny_light_stop.h"
-#include "./images/player_tiny_red_stop.h"
-//
-#include "./images/star_normal_tiny.h"
-#include "./images/star_normal_mid.h"
-#include "./images/star_normal_big.h"
-#include "./images/star_highlight_tiny.h"
-#include "./images/star_highlight_mid.h"
-#include "./images/star_highlight_big.h"
-//
-#include "./images/tiny_crossfade.h"
-#include "./images/tiny_gapless.h"
-//
-#include "./images/tiny_mv_library.h"
-#include "./images/tiny_mv_albumbrowser.h"
-#include "./images/tiny_mv_treeview.h"
-#include "./images/tiny_mv_playlists.h"
-
-// -------------------------------------------------------------------------------- //
-typedef struct {
-    const unsigned char * imgdata;
-    unsigned int          imgsize;
-    long                  imgtype;
-} guImage_Item;
-
-#define GUIMAGE( IMAGENAME, IMAGETYPE )    { IMAGENAME, sizeof( IMAGENAME ), IMAGETYPE }
-
-// -------------------------------------------------------------------------------- //
-guImage_Item guImage_Items[] = {
-    GUIMAGE( guImage_add,                           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_blank_cd_cover,                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_bookmark,                      wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_default_lastfm_image,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_del,                           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_doc_new,                       wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_doc_save,                      wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_download_covers,               wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_down,                          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_edit_clear,                    wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_edit_copy,                     wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_edit_delete,                   wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_edit,                          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_exit,                          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_filter,                        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_guayadeque,                    wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_guayadeque_taskbar,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_lastfm_as_off,                 wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_lastfm_as_on,                  wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_lastfm_on,                     wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_left,                          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_net_radio,                     wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_no_cover,                      wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_no_photo,                      wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_numerate,                      wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_right,                         wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_search,                        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_splash,                        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_system_run,                    wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tags,                          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_accept,                   wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_add,                      wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_del,                      wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_up,                            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_track,                         wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_search,                   wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_search_engine,	                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_musicbrainz,	                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_edit,                     wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_edit_copy,	            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_filter,	                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_search_again,             wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_numerate,	                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_edit_clear,               wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_podcast,                  	    wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_mid_podcast,                   wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_podcast,                  wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_status_pending,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_status_error,             wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_doc_save,                 wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_reload,                   wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_shoutcast,                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_tunein,                   wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_net_radio,                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_left,                     wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_right,                    wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_search_engine,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_library,                  wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_record,                   wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_commands,                 wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_copy_to,                  wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_general,                  wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_last_fm,                  wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_library,                  wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_links,                    wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_lyrics,                   wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_online_services,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_playback,                 wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_podcasts,                 wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_record,                   wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_crossfader,		        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_jamendo,		            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_magnatune,		        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_pref_accelerators,		        wxBITMAP_TYPE_PNG ),
-    //
-    GUIMAGE( guImage_loc_library,		            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_loc_portable_device,	        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_loc_net_radio,	                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_loc_podcast,	                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_loc_magnatune,	                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_loc_jamendo,	                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_loc_lastfm,	                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_loc_lyrics,			        wxBITMAP_TYPE_PNG ),
-    //
-    GUIMAGE( guImage_tiny_close_normal,		        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_close_highlight,	        wxBITMAP_TYPE_PNG ),
-    //
-    GUIMAGE( guImage_player_highlight_equalizer,    wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_muted,        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_next,         wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_pause,        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_play,         wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_prev,         wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_random,       wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_record,       wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_repeat,       wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_repeat_single, wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_search,       wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_setup,        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_smart,        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_stop,         wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_vol_hi,       wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_vol_low,      wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_vol_mid,      wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_love,         wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_highlight_ban,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_equalizer,        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_muted,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_next,             wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_pause,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_play,             wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_prev,             wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_random,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_record,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_repeat,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_repeat_single,    wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_search,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_setup,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_smart,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_stop,             wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_vol_hi,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_vol_low,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_vol_mid,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_love,             wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_light_ban,              wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_equalizer,       wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_muted,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_next,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_pause,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_play,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_prev,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_random,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_record,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_repeat,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_repeat_single,   wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_search,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_setup,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_smart,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_stop,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_vol_hi,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_vol_low,         wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_vol_mid,         wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_love,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_normal_ban,             wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_tiny_light_play,        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_tiny_light_stop,        wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_player_tiny_red_stop,          wxBITMAP_TYPE_PNG ),
-    //
-    GUIMAGE( guImage_star_normal_tiny,              wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_star_normal_mid,               wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_star_normal_big,               wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_star_highlight_tiny,           wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_star_highlight_mid,            wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_star_highlight_big,            wxBITMAP_TYPE_PNG ),
-    //
-    GUIMAGE( guImage_tiny_crossfade,                wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_gapless,                  wxBITMAP_TYPE_PNG ),
-    //
-    GUIMAGE( guImage_tiny_mv_library,               wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_mv_albumbrowser,          wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_mv_treeview,              wxBITMAP_TYPE_PNG ),
-    GUIMAGE( guImage_tiny_mv_playlists,             wxBITMAP_TYPE_PNG )
-};
-
-
-// -------------------------------------------------------------------------------- //
-wxBitmap guBitmap( guIMAGE_INDEX imageindex )
+namespace guNS_Image
 {
-    return wxBitmap( guImage( imageindex ) );
-}
+// -------------------------------------------------------------------------------- //
+    std::map<unsigned short, guIMG_ITEM> guImage_Items = {
+        { guIMAGE_INDEX_add,                            GUIMAGE( guImage_add )},
+        { guIMAGE_INDEX_blank_cd_cover,                 GUIMAGE( guImage_blank_cd_cover )},
+        { guIMAGE_INDEX_bookmark,                       GUIMAGE( guImage_bookmark )},
+        { guIMAGE_INDEX_default_lastfm_image,           GUIMAGE( guImage_default_lastfm_image )},
+        { guIMAGE_INDEX_del,                            GUIMAGE( guImage_del )},
+        { guIMAGE_INDEX_doc_new,                        GUIMAGE( guImage_doc_new )},
+        { guIMAGE_INDEX_doc_save,                       GUIMAGE( guImage_doc_save )},
+        { guIMAGE_INDEX_download_covers,                GUIMAGE( guImage_download_covers )},
+        { guIMAGE_INDEX_down,                           GUIMAGE( guImage_down )},
+        { guIMAGE_INDEX_edit_clear,                     GUIMAGE( guImage_edit_clear )},
+        { guIMAGE_INDEX_edit_copy,                      GUIMAGE( guImage_edit_copy )},
+        { guIMAGE_INDEX_edit_delete,                    GUIMAGE( guImage_edit_delete )},
+        { guIMAGE_INDEX_edit,                           GUIMAGE( guImage_edit )},
+        { guIMAGE_INDEX_exit,                           GUIMAGE( guImage_exit )},
+        { guIMAGE_INDEX_filter,                         GUIMAGE( guImage_filter )},
+        { guIMAGE_INDEX_guayadeque,                     GUIMAGE( guImage_guayadeque )},
+        { guIMAGE_INDEX_guayadeque_taskbar,             GUIMAGE( guImage_guayadeque_taskbar )},
+        { guIMAGE_INDEX_lastfm_as_off,                  GUIMAGE( guImage_lastfm_as_off )},
+        { guIMAGE_INDEX_lastfm_as_on,                   GUIMAGE( guImage_lastfm_as_on )},
+        { guIMAGE_INDEX_lastfm_on,                      GUIMAGE( guImage_lastfm_on )},
+        { guIMAGE_INDEX_left,                           GUIMAGE( guImage_left )},
+        { guIMAGE_INDEX_net_radio,                      GUIMAGE( guImage_net_radio )},
+        { guIMAGE_INDEX_no_cover,                       GUIMAGE( guImage_no_cover )},
+        { guIMAGE_INDEX_no_photo,                       GUIMAGE( guImage_no_photo )},
+        { guIMAGE_INDEX_numerate,                       GUIMAGE( guImage_numerate )},
+        { guIMAGE_INDEX_right,                          GUIMAGE( guImage_right )},
+        { guIMAGE_INDEX_search,                         GUIMAGE( guImage_search )},
+        { guIMAGE_INDEX_splash,                         GUIMAGE( guImage_splash )},
+        { guIMAGE_INDEX_system_run,                     GUIMAGE( guImage_system_run )},
+        { guIMAGE_INDEX_tags,                           GUIMAGE( guImage_tags )},
+        { guIMAGE_INDEX_tiny_accept,                    GUIMAGE( guImage_tiny_accept )},
+        { guIMAGE_INDEX_tiny_add,                       GUIMAGE( guImage_tiny_add )},
+        { guIMAGE_INDEX_tiny_del,                       GUIMAGE( guImage_tiny_del )},
+        { guIMAGE_INDEX_up,                             GUIMAGE( guImage_up )},
+        { guIMAGE_INDEX_track,                          GUIMAGE( guImage_track )},
+        { guIMAGE_INDEX_tiny_search,                    GUIMAGE( guImage_tiny_search )},
+        { guIMAGE_INDEX_search_engine,                  GUIMAGE( guImage_search_engine )},
+        { guIMAGE_INDEX_musicbrainz,                    GUIMAGE( guImage_musicbrainz )},
+        { guIMAGE_INDEX_tiny_edit,                      GUIMAGE( guImage_tiny_edit )},
+        { guIMAGE_INDEX_tiny_edit_copy,                 GUIMAGE( guImage_tiny_edit_copy )},
+        { guIMAGE_INDEX_tiny_filter,                    GUIMAGE( guImage_tiny_filter )},
+        { guIMAGE_INDEX_tiny_search_again,              GUIMAGE( guImage_tiny_search_again )},
+        { guIMAGE_INDEX_tiny_numerate,                  GUIMAGE( guImage_tiny_numerate )},
+        { guIMAGE_INDEX_tiny_edit_clear,                GUIMAGE( guImage_tiny_edit_clear )},
+        { guIMAGE_INDEX_podcast,                        GUIMAGE( guImage_podcast )},
+        { guIMAGE_INDEX_mid_podcast,                    GUIMAGE( guImage_mid_podcast )},
+        { guIMAGE_INDEX_tiny_podcast,                   GUIMAGE( guImage_tiny_podcast )},
+        { guIMAGE_INDEX_tiny_status_pending,            GUIMAGE( guImage_tiny_status_pending )},
+        { guIMAGE_INDEX_tiny_status_error,              GUIMAGE( guImage_tiny_status_error )},
+        { guIMAGE_INDEX_tiny_doc_save,                  GUIMAGE( guImage_tiny_doc_save )},
+        { guIMAGE_INDEX_tiny_reload,                    GUIMAGE( guImage_tiny_reload )},
+        { guIMAGE_INDEX_tiny_shoutcast,                 GUIMAGE( guImage_tiny_shoutcast )},
+        { guIMAGE_INDEX_tiny_tunein,                    GUIMAGE( guImage_tiny_tunein )},
+        { guIMAGE_INDEX_tiny_net_radio,                 GUIMAGE( guImage_tiny_net_radio )},
+        { guIMAGE_INDEX_tiny_left,                      GUIMAGE( guImage_tiny_left )},
+        { guIMAGE_INDEX_tiny_right,                     GUIMAGE( guImage_tiny_right )},
+        { guIMAGE_INDEX_tiny_search_engine,             GUIMAGE( guImage_tiny_search_engine )},
+        { guIMAGE_INDEX_tiny_library,                   GUIMAGE( guImage_tiny_library )},
+        { guIMAGE_INDEX_tiny_record,                    GUIMAGE( guImage_tiny_record )},
+        { guIMAGE_INDEX_pref_commands,                  GUIMAGE( guImage_pref_commands )},
+        { guIMAGE_INDEX_pref_copy_to,                   GUIMAGE( guImage_pref_copy_to )},
+        { guIMAGE_INDEX_pref_general,                   GUIMAGE( guImage_pref_general )},
+        { guIMAGE_INDEX_pref_last_fm,                   GUIMAGE( guImage_pref_last_fm )},
+        { guIMAGE_INDEX_pref_library,                   GUIMAGE( guImage_pref_library )},
+        { guIMAGE_INDEX_pref_links,                     GUIMAGE( guImage_pref_links )},
+        { guIMAGE_INDEX_pref_lyrics,                    GUIMAGE( guImage_pref_lyrics )},
+        { guIMAGE_INDEX_pref_online_services,           GUIMAGE( guImage_pref_online_services )},
+        { guIMAGE_INDEX_pref_playback,                  GUIMAGE( guImage_pref_playback )},
+        { guIMAGE_INDEX_pref_podcasts,                  GUIMAGE( guImage_pref_podcasts )},
+        { guIMAGE_INDEX_pref_record,                    GUIMAGE( guImage_pref_record )},
+        { guIMAGE_INDEX_pref_crossfader,                GUIMAGE( guImage_pref_crossfader )},
+        { guIMAGE_INDEX_pref_jamendo,                   GUIMAGE( guImage_pref_jamendo )},
+        { guIMAGE_INDEX_pref_magnatune,                 GUIMAGE( guImage_pref_magnatune )},
+        { guIMAGE_INDEX_pref_accelerators,              GUIMAGE( guImage_pref_accelerators )},
+        //
+        { guIMAGE_INDEX_loc_library,                    GUIMAGE( guImage_loc_library )},
+        { guIMAGE_INDEX_loc_portable_device,            GUIMAGE( guImage_loc_portable_device )},
+        { guIMAGE_INDEX_loc_net_radio,                  GUIMAGE( guImage_loc_net_radio )},
+        { guIMAGE_INDEX_loc_podcast,                    GUIMAGE( guImage_loc_podcast )},
+        { guIMAGE_INDEX_loc_magnatune,                  GUIMAGE( guImage_loc_magnatune )},
+        { guIMAGE_INDEX_loc_jamendo,                    GUIMAGE( guImage_loc_jamendo )},
+        { guIMAGE_INDEX_loc_lastfm,                     GUIMAGE( guImage_loc_lastfm )},
+        { guIMAGE_INDEX_loc_lyrics,                     GUIMAGE( guImage_loc_lyrics )},
+        //
+        { guIMAGE_INDEX_tiny_close_normal,              GUIMAGE( guImage_tiny_close_normal )},
+        { guIMAGE_INDEX_tiny_close_highlight,           GUIMAGE( guImage_tiny_close_highlight )},
+        //
+        { guIMAGE_INDEX_player_highlight_equalizer,     GUIMAGE( guImage_player_highlight_equalizer )},
+        { guIMAGE_INDEX_player_highlight_muted,         GUIMAGE( guImage_player_highlight_muted )},
+        { guIMAGE_INDEX_player_highlight_next,          GUIMAGE( guImage_player_highlight_next )},
+        { guIMAGE_INDEX_player_highlight_pause,         GUIMAGE( guImage_player_highlight_pause )},
+        { guIMAGE_INDEX_player_highlight_play,          GUIMAGE( guImage_player_highlight_play )},
+        { guIMAGE_INDEX_player_highlight_prev,          GUIMAGE( guImage_player_highlight_prev )},
+        { guIMAGE_INDEX_player_highlight_random,        GUIMAGE( guImage_player_highlight_random )},
+        { guIMAGE_INDEX_player_highlight_record,        GUIMAGE( guImage_player_highlight_record )},
+        { guIMAGE_INDEX_player_highlight_repeat,        GUIMAGE( guImage_player_highlight_repeat )},
+        { guIMAGE_INDEX_player_highlight_repeat_single, GUIMAGE( guImage_player_highlight_repeat_single )},
+        { guIMAGE_INDEX_player_highlight_search,        GUIMAGE( guImage_player_highlight_search )},
+        { guIMAGE_INDEX_player_highlight_setup,         GUIMAGE( guImage_player_highlight_setup )},
+        { guIMAGE_INDEX_player_highlight_smart,         GUIMAGE( guImage_player_highlight_smart )},
+        { guIMAGE_INDEX_player_highlight_stop,          GUIMAGE( guImage_player_highlight_stop )},
+        { guIMAGE_INDEX_player_highlight_vol_hi,        GUIMAGE( guImage_player_highlight_vol_hi )},
+        { guIMAGE_INDEX_player_highlight_vol_low,       GUIMAGE( guImage_player_highlight_vol_low )},
+        { guIMAGE_INDEX_player_highlight_vol_mid,       GUIMAGE( guImage_player_highlight_vol_mid )},
+        { guIMAGE_INDEX_player_highlight_love,          GUIMAGE( guImage_player_highlight_love )},
+        { guIMAGE_INDEX_player_highlight_ban,           GUIMAGE( guImage_player_highlight_ban )},
+        { guIMAGE_INDEX_player_light_equalizer,         GUIMAGE( guImage_player_light_equalizer )},
+        { guIMAGE_INDEX_player_light_muted,             GUIMAGE( guImage_player_light_muted )},
+        { guIMAGE_INDEX_player_light_next,              GUIMAGE( guImage_player_light_next )},
+        { guIMAGE_INDEX_player_light_pause,             GUIMAGE( guImage_player_light_pause )},
+        { guIMAGE_INDEX_player_light_play,              GUIMAGE( guImage_player_light_play )},
+        { guIMAGE_INDEX_player_light_prev,              GUIMAGE( guImage_player_light_prev )},
+        { guIMAGE_INDEX_player_light_random,            GUIMAGE( guImage_player_light_random )},
+        { guIMAGE_INDEX_player_light_record,            GUIMAGE( guImage_player_light_record )},
+        { guIMAGE_INDEX_player_light_repeat,            GUIMAGE( guImage_player_light_repeat )},
+        { guIMAGE_INDEX_player_light_repeat_single,     GUIMAGE( guImage_player_light_repeat_single )},
+        { guIMAGE_INDEX_player_light_search,            GUIMAGE( guImage_player_light_search )},
+        { guIMAGE_INDEX_player_light_setup,             GUIMAGE( guImage_player_light_setup )},
+        { guIMAGE_INDEX_player_light_smart,             GUIMAGE( guImage_player_light_smart )},
+        { guIMAGE_INDEX_player_light_stop,              GUIMAGE( guImage_player_light_stop )},
+        { guIMAGE_INDEX_player_light_vol_hi,            GUIMAGE( guImage_player_light_vol_hi )},
+        { guIMAGE_INDEX_player_light_vol_low,           GUIMAGE( guImage_player_light_vol_low )},
+        { guIMAGE_INDEX_player_light_vol_mid,           GUIMAGE( guImage_player_light_vol_mid )},
+        { guIMAGE_INDEX_player_light_love,              GUIMAGE( guImage_player_light_love )},
+        { guIMAGE_INDEX_player_light_ban,               GUIMAGE( guImage_player_light_ban )},
+        { guIMAGE_INDEX_player_normal_equalizer,        GUIMAGE( guImage_player_normal_equalizer )},
+        { guIMAGE_INDEX_player_normal_muted,            GUIMAGE( guImage_player_normal_muted )},
+        { guIMAGE_INDEX_player_normal_next,             GUIMAGE( guImage_player_normal_next )},
+        { guIMAGE_INDEX_player_normal_pause,            GUIMAGE( guImage_player_normal_pause )},
+        { guIMAGE_INDEX_player_normal_play,             GUIMAGE( guImage_player_normal_play )},
+        { guIMAGE_INDEX_player_normal_prev,             GUIMAGE( guImage_player_normal_prev )},
+        { guIMAGE_INDEX_player_normal_random,           GUIMAGE( guImage_player_normal_random )},
+        { guIMAGE_INDEX_player_normal_record,           GUIMAGE( guImage_player_normal_record )},
+        { guIMAGE_INDEX_player_normal_repeat,           GUIMAGE( guImage_player_normal_repeat )},
+        { guIMAGE_INDEX_player_normal_repeat_single,    GUIMAGE( guImage_player_normal_repeat_single )},
+        { guIMAGE_INDEX_player_normal_search,           GUIMAGE( guImage_player_normal_search )},
+        { guIMAGE_INDEX_player_normal_setup,            GUIMAGE( guImage_player_normal_setup )},
+        { guIMAGE_INDEX_player_normal_smart,            GUIMAGE( guImage_player_normal_smart )},
+        { guIMAGE_INDEX_player_normal_stop,             GUIMAGE( guImage_player_normal_stop )},
+        { guIMAGE_INDEX_player_normal_vol_hi,           GUIMAGE( guImage_player_normal_vol_hi )},
+        { guIMAGE_INDEX_player_normal_vol_low,          GUIMAGE( guImage_player_normal_vol_low )},
+        { guIMAGE_INDEX_player_normal_vol_mid,          GUIMAGE( guImage_player_normal_vol_mid )},
+        { guIMAGE_INDEX_player_normal_love,             GUIMAGE( guImage_player_normal_love )},
+        { guIMAGE_INDEX_player_normal_ban,              GUIMAGE( guImage_player_normal_ban )},
+        { guIMAGE_INDEX_player_tiny_light_play,         GUIMAGE( guImage_player_tiny_light_play )},
+        { guIMAGE_INDEX_player_tiny_light_stop,         GUIMAGE( guImage_player_tiny_light_stop )},
+        { guIMAGE_INDEX_player_tiny_red_stop,           GUIMAGE( guImage_player_tiny_red_stop )},
+        { guIMAGE_INDEX_star_normal_tiny,               GUIMAGE( guImage_star_normal_tiny )},
+        { guIMAGE_INDEX_star_normal_mid,                GUIMAGE( guImage_star_normal_mid )},
+        { guIMAGE_INDEX_star_normal_big,                GUIMAGE( guImage_star_normal_big )},
+        { guIMAGE_INDEX_star_highlight_tiny,            GUIMAGE( guImage_star_highlight_tiny )},
+        { guIMAGE_INDEX_star_highlight_mid,             GUIMAGE( guImage_star_highlight_mid )},
+        { guIMAGE_INDEX_star_highlight_big,             GUIMAGE( guImage_star_highlight_big )},
+        //
+        { guIMAGE_INDEX_tiny_crossfade,                 GUIMAGE( guImage_tiny_crossfade )},
+        { guIMAGE_INDEX_tiny_gapless,                   GUIMAGE( guImage_tiny_gapless )},
+        //
+        { guIMAGE_INDEX_tiny_mv_library,                GUIMAGE( guImage_tiny_mv_library )},
+        { guIMAGE_INDEX_tiny_mv_albumbrowser,           GUIMAGE( guImage_tiny_mv_albumbrowser )},
+        { guIMAGE_INDEX_tiny_mv_treeview,               GUIMAGE( guImage_tiny_mv_treeview )},
+        { guIMAGE_INDEX_tiny_mv_playlists,              GUIMAGE( guImage_tiny_mv_playlists )}
+    };
 
 // -------------------------------------------------------------------------------- //
-wxImage guImage( guIMAGE_INDEX imageindex )
-{
-    wxMemoryInputStream image_stream( guImage_Items[ imageindex ].imgdata,
-                                      guImage_Items[ imageindex ].imgsize );
-    return wxImage( image_stream, guImage_Items[ imageindex ].imgtype );
-}
+    wxBitmap GetBitmap( guIMAGE_INDEX imageindex )
+    {
+        wxBitmap retBM(wxNullBitmap);
+        guIMG_ITEM item = guImage_Items[imageindex];
+        retBM = wxBitmap::NewFromPNGData( item.IMGdata, item.IMGsize );
+        // For wxBITMAP_TYPE_XPM
+        // retBM = wxBitmap( item.IMGdata );
+        return retBM;
+    }
 
+// -------------------------------------------------------------------------------- //
+    wxIcon GetIcon( guIMAGE_INDEX imageindex )
+    {
+        wxIcon retIcon;
+        retIcon.CopyFromBitmap( GetBitmap(imageindex) );
+        return retIcon;
+    }
+
+// -------------------------------------------------------------------------------- //
+    wxImage GetImage( guIMAGE_INDEX imageindex )
+    {
+        wxBitmap getBM = GetBitmap( imageindex );
+        return getBM.ConvertToImage();
+    }
+
+// -------------------------------------------------------------------------------- //
+} //end guNS_Image
 // -------------------------------------------------------------------------------- //

--- a/src/Images.h
+++ b/src/Images.h
@@ -22,6 +22,7 @@
 
 #include <wx/bitmap.h>
 #include <wx/image.h>
+#include <wx/icon.h>
 
 enum guIMAGE_INDEX {
     guIMAGE_INDEX_add = 0,
@@ -189,8 +190,21 @@ enum guIMAGE_INDEX {
 
 
 // -------------------------------------------------------------------------------- //
-wxBitmap guBitmap( guIMAGE_INDEX imageindex );
-wxImage guImage( guIMAGE_INDEX imageindex );
+namespace guNS_Image
+{
+    const wxBitmapType GU_BM_TYPE = wxBITMAP_TYPE_PNG;
+
+    typedef struct guIMG_ITEM {
+        const unsigned char * IMGdata;
+        unsigned int          IMGsize;
+    } guIMG_ITEM;
+
+    #define GUIMAGE( IMAGENAME )    { IMAGENAME, sizeof( IMAGENAME ) }
+
+    wxBitmap GetBitmap( guIMAGE_INDEX imageindex );
+    wxIcon   GetIcon( guIMAGE_INDEX imageindex );
+    wxImage  GetImage( guIMAGE_INDEX imageindex );
+}
 
 #endif
 // -------------------------------------------------------------------------------- //

--- a/src/ImportFiles.cpp
+++ b/src/ImportFiles.cpp
@@ -98,87 +98,87 @@ void guImportFiles::CreateControls( void )
     guMediaCollection * MediaCollection = m_MediaViewer->GetMediaCollection();
     int CopyToIndex = CopyToOptions.Index( MediaCollection->m_DefaultCopyAction );
 
-	m_CopyToChoice = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, CopyToOptions, 0 );
-	m_CopyToChoice->SetSelection( CopyToIndex );
-	CopyToChoiceSIzer->Add( m_CopyToChoice, 1, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxEXPAND, 5 );
+    m_CopyToChoice = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, CopyToOptions, 0 );
+    m_CopyToChoice->SetSelection( CopyToIndex );
+    CopyToChoiceSIzer->Add( m_CopyToChoice, 1, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxEXPAND, 5 );
 
-	m_CopyToSetupBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_search_engine ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	CopyToChoiceSIzer->Add( m_CopyToSetupBtn, 0, wxTOP|wxBOTTOM|wxRIGHT, 5 );
+    m_CopyToSetupBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search_engine ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    CopyToChoiceSIzer->Add( m_CopyToSetupBtn, 0, wxTOP|wxBOTTOM|wxRIGHT, 5 );
 
-	CopyToSizer->Add( CopyToChoiceSIzer, 1, wxEXPAND, 5 );
+    CopyToSizer->Add( CopyToChoiceSIzer, 1, wxEXPAND, 5 );
 
-	wxStaticText * DestPathStaticText = new wxStaticText( this, wxID_ANY, _( "Destination Folder:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	DestPathStaticText->Wrap( -1 );
-	CopyToSizer->Add( DestPathStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
+    wxStaticText * DestPathStaticText = new wxStaticText( this, wxID_ANY, _( "Destination Folder:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    DestPathStaticText->Wrap( -1 );
+    CopyToSizer->Add( DestPathStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
-	m_DestPathDirPicker = new wxDirPickerCtrl( this, wxID_ANY, wxEmptyString, _( "Select a folder" ), wxDefaultPosition, wxDefaultSize, wxDIRP_DEFAULT_STYLE|wxDIRP_DIR_MUST_EXIST );
+    m_DestPathDirPicker = new wxDirPickerCtrl( this, wxID_ANY, wxEmptyString, _( "Select a folder" ), wxDefaultPosition, wxDefaultSize, wxDIRP_DEFAULT_STYLE|wxDIRP_DIR_MUST_EXIST );
     m_DestPathDirPicker->SetPath( m_MediaViewer->AudioPath() );
-	CopyToSizer->Add( m_DestPathDirPicker, 0, wxEXPAND|wxBOTTOM|wxRIGHT, 5 );
+    CopyToSizer->Add( m_DestPathDirPicker, 0, wxEXPAND|wxBOTTOM|wxRIGHT, 5 );
 
-	MainStaticBoxSizer->Add( CopyToSizer, 0, wxEXPAND, 5 );
+    MainStaticBoxSizer->Add( CopyToSizer, 0, wxEXPAND, 5 );
 
-	wxStaticBoxSizer * FilesSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _( " Files " ) ), wxVERTICAL );
+    wxStaticBoxSizer * FilesSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _( " Files " ) ), wxVERTICAL );
 
-	m_FilesListBox = new wxListBox( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_MULTIPLE );
-	Count = m_Tracks->Count();
-	for( Index = 0; Index < Count; Index++ )
-	{
-	    const guTrack & CurTrack = m_Tracks->Item( Index );
-	    wxString CurFile = CurTrack.m_FileName.AfterLast( wxT( '/' ) );
-	    if( CurTrack.m_Offset )
-	    {
-            CurFile += wxT( "@" ) + LenToString( CurTrack.m_Offset );
-            CurFile += wxT( " / " ) + LenToString( CurTrack.m_Length );
-	    }
+    m_FilesListBox = new wxListBox( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_MULTIPLE );
+    Count = m_Tracks->Count();
+    for( Index = 0; Index < Count; Index++ )
+    {
+        const guTrack & CurTrack = m_Tracks->Item( Index );
+        wxString CurFile = CurTrack.m_FileName.AfterLast( wxT( '/' ) );
+        if( CurTrack.m_Offset )
+        {
+        CurFile += wxT( "@" ) + LenToString( CurTrack.m_Offset );
+        CurFile += wxT( " / " ) + LenToString( CurTrack.m_Length );
+        }
 
-	    m_FilesListBox->Append( CurFile );
-	}
-	FilesSizer->Add( m_FilesListBox, 1, wxEXPAND|wxALL, 5 );
+        m_FilesListBox->Append( CurFile );
+    }
+    FilesSizer->Add( m_FilesListBox, 1, wxEXPAND|wxALL, 5 );
 
-	wxBoxSizer * AddFilesSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer * AddFilesSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	m_AddFilesBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	AddFilesSizer->Add( m_AddFilesBtn, 0, wxLEFT, 5 );
+    m_AddFilesBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    AddFilesSizer->Add( m_AddFilesBtn, 0, wxLEFT, 5 );
 
-	m_DelFilesBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_DelFilesBtn->Enable( false );
-	AddFilesSizer->Add( m_DelFilesBtn, 0, wxRIGHT, 5 );
+    m_DelFilesBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_DelFilesBtn->Enable( false );
+    AddFilesSizer->Add( m_DelFilesBtn, 0, wxRIGHT, 5 );
 
 
-	AddFilesSizer->Add( 0, 0, 1, wxEXPAND, 5 );
+    AddFilesSizer->Add( 0, 0, 1, wxEXPAND, 5 );
 
-	m_FilesLabel = new wxStaticText( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	m_FilesLabel->Wrap( -1 );
-	AddFilesSizer->Add( m_FilesLabel, 0, wxRIGHT|wxLEFT|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
+    m_FilesLabel = new wxStaticText( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    m_FilesLabel->Wrap( -1 );
+    AddFilesSizer->Add( m_FilesLabel, 0, wxRIGHT|wxLEFT|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 
-	FilesSizer->Add( AddFilesSizer, 0, wxEXPAND, 5 );
+    FilesSizer->Add( AddFilesSizer, 0, wxEXPAND, 5 );
 
-	MainStaticBoxSizer->Add( FilesSizer, 1, wxEXPAND, 5 );
+    MainStaticBoxSizer->Add( FilesSizer, 1, wxEXPAND, 5 );
 
-	MainSizer->Add( MainStaticBoxSizer, 1, wxEXPAND|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
+    MainSizer->Add( MainStaticBoxSizer, 1, wxEXPAND|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
-	wxStdDialogButtonSizer * DlgButtons = new wxStdDialogButtonSizer();
-	m_DlgButtonsOK = new wxButton( this, wxID_OK );
-	m_DlgButtonsOK->Enable( !m_CopyToChoice->GetStringSelection().IsEmpty() && !m_DestPathDirPicker->GetPath().IsEmpty() && !m_FilesListBox->IsEmpty() );
-	DlgButtons->AddButton( m_DlgButtonsOK );
-	wxButton * DlgButtonsCancel = new wxButton( this, wxID_CANCEL );
-	DlgButtons->AddButton( DlgButtonsCancel );
-	DlgButtons->SetAffirmativeButton( m_DlgButtonsOK );
-	DlgButtons->SetCancelButton( DlgButtonsCancel );
-	DlgButtons->Realize();
-	MainSizer->Add( DlgButtons, 0, wxEXPAND|wxALL, 5 );
+    wxStdDialogButtonSizer * DlgButtons = new wxStdDialogButtonSizer();
+    m_DlgButtonsOK = new wxButton( this, wxID_OK );
+    m_DlgButtonsOK->Enable( !m_CopyToChoice->GetStringSelection().IsEmpty() && !m_DestPathDirPicker->GetPath().IsEmpty() && !m_FilesListBox->IsEmpty() );
+    DlgButtons->AddButton( m_DlgButtonsOK );
+    wxButton * DlgButtonsCancel = new wxButton( this, wxID_CANCEL );
+    DlgButtons->AddButton( DlgButtonsCancel );
+    DlgButtons->SetAffirmativeButton( m_DlgButtonsOK );
+    DlgButtons->SetCancelButton( DlgButtonsCancel );
+    DlgButtons->Realize();
+    MainSizer->Add( DlgButtons, 0, wxEXPAND|wxALL, 5 );
 
-	SetSizer( MainSizer );
-	Layout();
+    SetSizer( MainSizer );
+    Layout();
 
-	m_DlgButtonsOK->SetDefault();
+    m_DlgButtonsOK->SetDefault();
 
-	UpdateCounters();
+    UpdateCounters();
 
-	m_CopyToSetupBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guImportFiles::OnCopyToSetupClicked ), NULL, this );
-	m_FilesListBox->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( guImportFiles::OnFileSelected ), NULL, this );
-	m_AddFilesBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guImportFiles::OnAddFilesClicked ), NULL, this );
-	m_DelFilesBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guImportFiles::OnDelFilesClicked ), NULL, this );
+    m_CopyToSetupBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guImportFiles::OnCopyToSetupClicked ), NULL, this );
+    m_FilesListBox->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( guImportFiles::OnFileSelected ), NULL, this );
+    m_AddFilesBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guImportFiles::OnAddFilesClicked ), NULL, this );
+    m_DelFilesBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guImportFiles::OnDelFilesClicked ), NULL, this );
 
     Connect( ID_CONFIG_UPDATED, guConfigUpdatedEvent, wxCommandEventHandler( guImportFiles::OnConfigUpdated ), NULL, this );
 }

--- a/src/LabelEditor.cpp
+++ b/src/LabelEditor.cpp
@@ -114,19 +114,19 @@ guLabelEditor::guLabelEditor( wxWindow * parent, guDbLibrary * db, const wxStrin
 
 	ButtonsSizer->Add( 0, 0, 1, wxEXPAND, 5 );
 
-	m_AddButton = new wxBitmapButton( m_LabelsPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_AddButton = new wxBitmapButton( m_LabelsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_AddButton->SetToolTip( _("Add a new label") );
 
 	ButtonsSizer->Add( m_AddButton, 0, wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
-	m_DelButton = new wxBitmapButton( m_LabelsPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_DelButton = new wxBitmapButton( m_LabelsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_DelButton->Enable( false );
 	m_DelButton->SetToolTip( _("Delete the current selected label") );
 
 
 	ButtonsSizer->Add( m_DelButton, 0, wxBOTTOM|wxRIGHT, 5 );
 
-	m_CopyButton = new wxBitmapButton( m_LabelsPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_CopyButton = new wxBitmapButton( m_LabelsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_CopyButton->SetToolTip( _("Copy the label selection to all the items") );
 
 	ButtonsSizer->Add( m_CopyButton, 0, wxBOTTOM|wxRIGHT|wxLEFT, 5 );

--- a/src/LastFMPanel.cpp
+++ b/src/LastFMPanel.cpp
@@ -160,24 +160,24 @@ guLastFMInfoCtrl::~guLastFMInfoCtrl()
 // -------------------------------------------------------------------------------- //
 void guLastFMInfoCtrl::CreateControls( wxWindow * parent )
 {
-	wxBoxSizer* MainSizer;
-	MainSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer* MainSizer;
+    MainSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	m_Bitmap = new wxStaticBitmap( this, wxID_ANY, guImage( guIMAGE_INDEX_default_lastfm_image ),
-	                                            wxDefaultPosition, wxSize( 50, 50 ), 0 );
+    m_Bitmap = new wxStaticBitmap( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_default_lastfm_image ),
+                                                wxDefaultPosition, wxSize( 50, 50 ), 0 );
     //Bitmap->SetCursor( wxCURSOR_HAND );
-	MainSizer->Add( m_Bitmap, 0, wxALL|wxALIGN_CENTER_VERTICAL, 2 );
+    MainSizer->Add( m_Bitmap, 0, wxALL|wxALIGN_CENTER_VERTICAL, 2 );
 
-	m_Text = new wxStaticText( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 200, -1 ), 0 );
-	m_Text->Wrap( -1 );
-	//Text->SetCursor( wxCursor( wxCURSOR_HAND ) );
-	//m_Text->SetMaxSize( wxSize( 250, -1 ) );
-	MainSizer->Add( m_Text, 1, wxALL|wxEXPAND|wxALIGN_CENTER_VERTICAL, 2 );
+    m_Text = new wxStaticText( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 200, -1 ), 0 );
+    m_Text->Wrap( -1 );
+    //Text->SetCursor( wxCursor( wxCURSOR_HAND ) );
+    //m_Text->SetMaxSize( wxSize( 250, -1 ) );
+    MainSizer->Add( m_Text, 1, wxALL|wxEXPAND|wxALIGN_CENTER_VERTICAL, 2 );
 
 
-	SetSizer( MainSizer );
-	Layout();
-	MainSizer->Fit( this );
+    SetSizer( MainSizer );
+    Layout();
+    MainSizer->Fit( this );
 
 //    Connect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( guLastFMInfoCtrl::OnDoubleClicked ), NULL, this );
 //    m_Bitmap->Connect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( guLastFMInfoCtrl::OnDoubleClicked ), NULL, this );
@@ -187,7 +187,7 @@ void guLastFMInfoCtrl::CreateControls( wxWindow * parent )
     m_Text->Connect( wxEVT_LEAVE_WINDOW, wxMouseEventHandler( guLastFMInfoCtrl::OnMouse ), NULL, this );
     m_Text->Connect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( guLastFMInfoCtrl::OnMouse ), NULL, this );
 
-	m_Bitmap->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler( guLastFMInfoCtrl::OnBitmapClicked ), NULL, this );
+    m_Bitmap->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler( guLastFMInfoCtrl::OnBitmapClicked ), NULL, this );
 }
 
 // -------------------------------------------------------------------------------- //
@@ -201,7 +201,7 @@ void guLastFMInfoCtrl::SetMediaViewer( guMediaViewer * mediaviewer )
 // -------------------------------------------------------------------------------- //
 void guLastFMInfoCtrl::Clear( guMediaViewer * mediaviewer )
 {
-    m_Bitmap->SetBitmap( guImage( guIMAGE_INDEX_default_lastfm_image ) );
+    m_Bitmap->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_default_lastfm_image ) );
     m_Text->SetLabel( wxEmptyString );
     //
     SetMediaViewer( mediaviewer );
@@ -216,7 +216,7 @@ void guLastFMInfoCtrl::SetBitmap( const wxImage * image )
     }
     else
     {
-        m_Bitmap->SetBitmap( guImage( guIMAGE_INDEX_default_lastfm_image ) );
+        m_Bitmap->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_default_lastfm_image ) );
     }
     m_Bitmap->Refresh();
 }
@@ -417,7 +417,7 @@ void guArtistInfoCtrl::CreateControls( wxWindow * parent )
 {
 	m_MainSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	m_Bitmap = new wxStaticBitmap( this, wxID_ANY, guImage( guIMAGE_INDEX_no_photo ), wxDefaultPosition, wxSize( 100,100 ), 0 );
+	m_Bitmap = new wxStaticBitmap( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_no_photo ), wxDefaultPosition, wxSize( 100,100 ), 0 );
 	m_MainSizer->Add( m_Bitmap, 0, wxALL, 5 );
 
 //	wxBoxSizer * DetailSizer;
@@ -507,7 +507,7 @@ void guArtistInfoCtrl::SetMediaViewer( guMediaViewer * mediaviewer )
 // -------------------------------------------------------------------------------- //
 void guArtistInfoCtrl::Clear( guMediaViewer * mediaviewer )
 {
-    m_Bitmap->SetBitmap( guImage( guIMAGE_INDEX_no_photo ) );
+    m_Bitmap->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_no_photo ) );
     m_Text->SetLabel( wxEmptyString );
 
     if( m_Info )
@@ -528,7 +528,7 @@ void guArtistInfoCtrl::SetBitmap( const wxImage * image )
     }
     else
     {
-        m_Bitmap->SetBitmap( guImage( guIMAGE_INDEX_no_photo ) );
+        m_Bitmap->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_no_photo ) );
     }
     m_Bitmap->Refresh();
 }
@@ -554,11 +554,11 @@ void guArtistInfoCtrl::CreateContextMenu( wxMenu * Menu )
     {
         //guLogMessage( wxT( "The artist id = %i" ), m_Info->m_ArtistId );
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_PLAY, _( "Play" ), _( "Play the artist tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_ENQUEUE_AFTER_ALL, _( "Enqueue" ), _( "Enqueue the artist tracks to the playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         Menu->Append( MenuItem );
 
         wxMenu * EnqueueMenu = new wxMenu();
@@ -566,19 +566,19 @@ void guArtistInfoCtrl::CreateContextMenu( wxMenu * Menu )
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_TRACK,
                                 wxString( _( "Current Track" ) ),
                                 _( "Add current selected tracks to playlist after the current track" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ALBUM,
                                 wxString( _( "Current Album" ) ),
                                 _( "Add current selected tracks to playlist after the current album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ARTIST,
                                 wxString( _( "Current Artist" ) ),
                                 _( "Add current selected tracks to playlist after the current artist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         Menu->Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -586,7 +586,7 @@ void guArtistInfoCtrl::CreateContextMenu( wxMenu * Menu )
         Menu->AppendSeparator();
 
         MenuItem = new wxMenuItem( Menu, ID_ARTIST_SELECTNAME, _( "Search Artist" ), _( "Search the artist in the library" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -594,7 +594,7 @@ void guArtistInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( !GetSearchText().IsEmpty() )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_COPYTOCLIPBOARD, _( "Copy to Clipboard" ), _( "Copy the artist name to clipboard" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_copy ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_copy ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -602,7 +602,7 @@ void guArtistInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( !m_Info->m_Artist->m_Url.IsEmpty() )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_VISIT_URL, wxT( "Last.fm" ), _( "Visit last.fm page for this item" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_lastfm_as_on ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_lastfm_as_on ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -816,11 +816,11 @@ void guAlbumInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( m_Info->m_AlbumId != wxNOT_FOUND )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_PLAY, _( "Play" ), _( "Play the album tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_ENQUEUE_AFTER_ALL, _( "Enqueue" ), _( "Enqueue the album tracks to the playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         Menu->Append( MenuItem );
 
         wxMenu * EnqueueMenu = new wxMenu();
@@ -828,19 +828,19 @@ void guAlbumInfoCtrl::CreateContextMenu( wxMenu * Menu )
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_TRACK,
                                 wxString( _( "Current Track" ) ),
                                 _( "Add current selected tracks to playlist after the current track" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ALBUM,
                                 wxString( _( "Current Album" ) ),
                                 _( "Add current selected tracks to playlist after the current album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ARTIST,
                                 wxString( _( "Current Artist" ) ),
                                 _( "Add current selected tracks to playlist after the current artist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         Menu->Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -848,7 +848,7 @@ void guAlbumInfoCtrl::CreateContextMenu( wxMenu * Menu )
         Menu->AppendSeparator();
 
         MenuItem = new wxMenuItem( Menu, ID_ALBUM_SELECTNAME, _( "Search Album" ), _( "Search the album in the library" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -856,7 +856,7 @@ void guAlbumInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( !GetSearchText().IsEmpty() )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_COPYTOCLIPBOARD, _( "Copy to Clipboard" ), _( "Copy the album info to clipboard" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_copy ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_copy ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -864,7 +864,7 @@ void guAlbumInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( !m_Info->m_Album->m_Url.IsEmpty() )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_VISIT_URL, wxT( "Last.fm" ), _( "Visit last.fm page for this item" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_lastfm_as_on ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_lastfm_as_on ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1010,11 +1010,11 @@ void guSimilarArtistInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( m_Info->m_ArtistId != wxNOT_FOUND )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_PLAY, _( "Play" ), _( "Play the artist tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_ENQUEUE_AFTER_ALL, _( "Enqueue" ), _( "Enqueue the artist tracks to the playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         Menu->Append( MenuItem );
 
         wxMenu * EnqueueMenu = new wxMenu();
@@ -1022,19 +1022,19 @@ void guSimilarArtistInfoCtrl::CreateContextMenu( wxMenu * Menu )
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_TRACK,
                                 wxString( _( "Current Track" ) ),
                                 _( "Add current selected tracks to playlist after the current track" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ALBUM,
                                 wxString( _( "Current Album" ) ),
                                 _( "Add current selected tracks to playlist after the current album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ARTIST,
                                 wxString( _( "Current Artist" ) ),
                                 _( "Add current selected tracks to playlist after the current artist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         Menu->Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -1042,7 +1042,7 @@ void guSimilarArtistInfoCtrl::CreateContextMenu( wxMenu * Menu )
         Menu->AppendSeparator();
 
         MenuItem = new wxMenuItem( Menu, ID_ARTIST_SELECTNAME, _( "Search Artist" ), _( "Search the artist in the library" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1052,7 +1052,7 @@ void guSimilarArtistInfoCtrl::CreateContextMenu( wxMenu * Menu )
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_SELECT_ARTIST, _( "Show Artist Info" ), _( "Update the information with the current selected artist" ) );
         Menu->Append( MenuItem );
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_COPYTOCLIPBOARD, _( "Copy to Clipboard" ), _( "Copy the artist info to clipboard" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_copy ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_copy ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1060,7 +1060,7 @@ void guSimilarArtistInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( !m_Info->m_Artist->m_Url.IsEmpty() )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_VISIT_URL, wxT( "Last.fm" ), _( "Visit last.fm page for this item" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_lastfm_as_on ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_lastfm_as_on ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1210,11 +1210,11 @@ void guTrackInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( m_Info->m_TrackId != wxNOT_FOUND )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_PLAY, _( "Play" ), _( "Play the artist tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_ENQUEUE_AFTER_ALL, _( "Enqueue" ), _( "Enqueue the artist tracks to the playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         Menu->Append( MenuItem );
 
         wxMenu * EnqueueMenu = new wxMenu();
@@ -1222,19 +1222,19 @@ void guTrackInfoCtrl::CreateContextMenu( wxMenu * Menu )
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_TRACK,
                                 wxString( _( "Current Track" ) ),
                                 _( "Add current selected tracks to playlist after the current track" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ALBUM,
                                 wxString( _( "Current Album" ) ),
                                 _( "Add current selected tracks to playlist after the current album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ARTIST,
                                 wxString( _( "Current Artist" ) ),
                                 _( "Add current selected tracks to playlist after the current artist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         Menu->Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -1242,11 +1242,11 @@ void guTrackInfoCtrl::CreateContextMenu( wxMenu * Menu )
         Menu->AppendSeparator();
 
         MenuItem = new wxMenuItem( Menu, ID_TRACKS_SELECTNAME, _( "Search Track" ), _( "Search the track in the library" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_ARTIST_SELECTNAME, _( "Search Artist" ), _( "Search the artist in the library" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1257,7 +1257,7 @@ void guTrackInfoCtrl::CreateContextMenu( wxMenu * Menu )
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_COPYTOCLIPBOARD, _( "Copy to Clipboard" ), _( "Copy the track info to clipboard" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_copy ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_copy ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1265,7 +1265,7 @@ void guTrackInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( !m_Info->m_Track->m_Url.IsEmpty() )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_VISIT_URL, wxT( "Last.fm" ), _( "Visit last.fm page for this item" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_lastfm_as_on ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_lastfm_as_on ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1418,11 +1418,11 @@ void guTopTrackInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( m_Info->m_TrackId != wxNOT_FOUND )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_PLAY, _( "Play" ), _( "Play the artist tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_ENQUEUE_AFTER_ALL, _( "Enqueue" ), _( "Enqueue the artist tracks to the playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         Menu->Append( MenuItem );
 
         wxMenu * EnqueueMenu = new wxMenu();
@@ -1430,19 +1430,19 @@ void guTopTrackInfoCtrl::CreateContextMenu( wxMenu * Menu )
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_TRACK,
                                 wxString( _( "Current Track" ) ),
                                 _( "Add current selected tracks to playlist after the current track" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ALBUM,
                                 wxString( _( "Current Album" ) ),
                                 _( "Add current selected tracks to playlist after the current album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ARTIST,
                                 wxString( _( "Current Artist" ) ),
                                 _( "Add current selected tracks to playlist after the current artist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         Menu->Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -1450,11 +1450,11 @@ void guTopTrackInfoCtrl::CreateContextMenu( wxMenu * Menu )
         Menu->AppendSeparator();
 
         MenuItem = new wxMenuItem( Menu, ID_TRACKS_SELECTNAME, _( "Search Track" ), _( "Search the track in the library" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_ARTIST_SELECTNAME, _( "Search Artist" ), _( "Search the artist in the library" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1462,7 +1462,7 @@ void guTopTrackInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( !GetSearchText().IsEmpty() )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_COPYTOCLIPBOARD, _( "Copy to Clipboard" ), _( "Copy the track info to clipboard" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_copy ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_copy ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1470,7 +1470,7 @@ void guTopTrackInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( !m_Info->m_TopTrack->m_Url.IsEmpty() )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_VISIT_URL, wxT( "Last.fm" ), _( "Visit last.fm page for this item" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_lastfm_as_on ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_lastfm_as_on ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1587,7 +1587,7 @@ void guEventInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( !GetSearchText().IsEmpty() )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_COPYTOCLIPBOARD, _( "Copy to Clipboard" ), _( "Copy the event info to clipboard" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_copy ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_copy ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1595,7 +1595,7 @@ void guEventInfoCtrl::CreateContextMenu( wxMenu * Menu )
     if( !m_Info->m_Event->m_Url.IsEmpty() )
     {
         MenuItem = new wxMenuItem( Menu, ID_LASTFM_VISIT_URL, wxT( "Last.fm" ), _( "Visit last.fm page for this item" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_lastfm_as_on ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_lastfm_as_on ) );
         Menu->Append( MenuItem );
         Menu->AppendSeparator();
     }
@@ -1665,15 +1665,15 @@ guLastFMPanel::guLastFMPanel( wxWindow * Parent, guDbLibrary * db,
 	m_UpdateCheckBox->SetValue( m_UpdateEnabled );
 	EditorSizer->Add( m_UpdateCheckBox, 0, wxEXPAND|wxALIGN_CENTER_VERTICAL|wxTOP|wxLEFT, 5 );
 
-	m_PrevButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_PrevButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_PrevButton->Enable( false );
 	EditorSizer->Add( m_PrevButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxLEFT, 5 );
 
-	m_NextButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_NextButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_NextButton->Enable( false );
 	EditorSizer->Add( m_NextButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP, 5 );
 
-	m_ReloadButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_reload ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_ReloadButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_reload ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_ReloadButton->Enable( false );
 	EditorSizer->Add( m_ReloadButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
@@ -1756,11 +1756,11 @@ guLastFMPanel::guLastFMPanel( wxWindow * Parent, guDbLibrary * db,
 	m_AlbumsStaticText->Wrap( -1 );
 	AlTitleSizer->Add( m_AlbumsRangeLabel, 0, wxLEFT|wxTOP|wxBOTTOM, 5 );
 
-    m_AlbumsPrevBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_AlbumsPrevBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_AlbumsPrevBtn->Enable( false );
 	AlTitleSizer->Add( m_AlbumsPrevBtn, 0, wxLEFT, 5 );
 
-    m_AlbumsNextBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_AlbumsNextBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_AlbumsNextBtn->Enable( false );
 	AlTitleSizer->Add( m_AlbumsNextBtn, 0, wxRIGHT, 5 );
 
@@ -1797,11 +1797,11 @@ guLastFMPanel::guLastFMPanel( wxWindow * Parent, guDbLibrary * db,
 	m_AlbumsStaticText->Wrap( -1 );
 	TopTracksTitleSizer->Add( m_TopTracksRangeLabel, 0, wxLEFT|wxTOP|wxBOTTOM, 5 );
 
-    m_TopTracksPrevBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_TopTracksPrevBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_TopTracksPrevBtn->Enable( false );
 	TopTracksTitleSizer->Add( m_TopTracksPrevBtn, 0, wxLEFT, 5 );
 
-    m_TopTracksNextBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_TopTracksNextBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_TopTracksNextBtn->Enable( false );
 	TopTracksTitleSizer->Add( m_TopTracksNextBtn, 0, wxRIGHT, 5 );
 
@@ -1838,11 +1838,11 @@ guLastFMPanel::guLastFMPanel( wxWindow * Parent, guDbLibrary * db,
 	m_AlbumsStaticText->Wrap( -1 );
 	SimArTitleSizer->Add( m_SimArtistsRangeLabel, 0, wxLEFT|wxTOP|wxBOTTOM, 5 );
 
-    m_SimArtistsPrevBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_SimArtistsPrevBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_SimArtistsPrevBtn->Enable( false );
 	SimArTitleSizer->Add( m_SimArtistsPrevBtn, 0, wxLEFT, 5 );
 
-    m_SimArtistsNextBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_SimArtistsNextBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_SimArtistsNextBtn->Enable( false );
 	SimArTitleSizer->Add( m_SimArtistsNextBtn, 0, wxRIGHT, 5 );
 
@@ -1879,11 +1879,11 @@ guLastFMPanel::guLastFMPanel( wxWindow * Parent, guDbLibrary * db,
 	m_AlbumsStaticText->Wrap( -1 );
 	SimTracksTitleSizer->Add( m_SimTracksRangeLabel, 0, wxLEFT|wxTOP|wxBOTTOM, 5 );
 
-    m_SimTracksPrevBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_SimTracksPrevBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_SimTracksPrevBtn->Enable( false );
 	SimTracksTitleSizer->Add( m_SimTracksPrevBtn, 0, wxLEFT, 5 );
 
-    m_SimTracksNextBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_SimTracksNextBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_SimTracksNextBtn->Enable( false );
 	SimTracksTitleSizer->Add( m_SimTracksNextBtn, 0, wxRIGHT, 5 );
 
@@ -1920,11 +1920,11 @@ guLastFMPanel::guLastFMPanel( wxWindow * Parent, guDbLibrary * db,
 	m_AlbumsStaticText->Wrap( -1 );
 	EventsTitleSizer->Add( m_EventsRangeLabel, 0, wxLEFT|wxTOP|wxBOTTOM, 5 );
 
-    m_EventsPrevBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_EventsPrevBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_left ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_EventsPrevBtn->Enable( false );
 	EventsTitleSizer->Add( m_EventsPrevBtn, 0, wxLEFT, 5 );
 
-    m_EventsNextBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_EventsNextBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_right ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_EventsNextBtn->Enable( false );
 	EventsTitleSizer->Add( m_EventsNextBtn, 0, wxRIGHT, 5 );
 
@@ -3161,11 +3161,11 @@ void guLastFMPanel::OnContextMenu( wxContextMenuEvent &event )
     }
 
     wxMenuItem * MenuItem = new wxMenuItem( &Menu, ID_LASTFM_PLAY, _( "Play" ), _( "Play the artist tracks" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu.Append( MenuItem );
 
     MenuItem = new wxMenuItem( &Menu, ID_LASTFM_ENQUEUE_AFTER_ALL, _( "Enqueue" ), _( "Enqueue the artist tracks to the playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu.Append( MenuItem );
 
     wxMenu * EnqueueMenu = new wxMenu();
@@ -3173,19 +3173,19 @@ void guLastFMPanel::OnContextMenu( wxContextMenuEvent &event )
     MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_LASTFM_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
 
     Menu.Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -3193,7 +3193,7 @@ void guLastFMPanel::OnContextMenu( wxContextMenuEvent &event )
     Menu.AppendSeparator();
 
     MenuItem = new wxMenuItem( &Menu, ID_LASTFM_SAVETOPLAYLIST, _( "Save to Playlist" ), _( "Save the selected tracks to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
     Menu.Append( MenuItem );
 
     Menu.AppendSeparator();

--- a/src/ListView.cpp
+++ b/src/ListView.cpp
@@ -1502,11 +1502,11 @@ guListViewColEdit::guListViewColEdit( wxWindow * parent, guListViewColumnArray *
 	wxBoxSizer * BtnsSizer;
 	BtnsSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_UpBitmapBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_UpBitmapBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_UpBitmapBtn->Enable( false );
 	BtnsSizer->Add( m_UpBitmapBtn, 0, wxTOP|wxBOTTOM, 5 );
 
-	m_DownBitmapBtn = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_DownBitmapBtn = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_DownBitmapBtn->Enable( false );
 	BtnsSizer->Add( m_DownBitmapBtn, 0, wxTOP|wxBOTTOM, 5 );
 

--- a/src/LocationPanel.cpp
+++ b/src/LocationPanel.cpp
@@ -74,15 +74,15 @@ guLocationTreeCtrl::guLocationTreeCtrl( wxWindow * parent, guMainFrame * mainfra
     m_LockCount = 0;
 
     m_ImageList = new wxImageList();
-    m_ImageList->Add( guImage( guIMAGE_INDEX_loc_library ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_loc_portable_device ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_loc_net_radio ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_loc_podcast ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_loc_magnatune ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_loc_jamendo ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_loc_lastfm ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_tiny_shoutcast ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_loc_lyrics ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_loc_library ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_loc_portable_device ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_loc_net_radio ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_loc_podcast ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_loc_magnatune ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_loc_jamendo ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_loc_lastfm ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_tiny_shoutcast ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_loc_lyrics ) );
 
     AssignImageList( m_ImageList );
 

--- a/src/LyricsPanel.cpp
+++ b/src/LyricsPanel.cpp
@@ -82,26 +82,26 @@ guLyricsPanel::guLyricsPanel( wxWindow * parent, guDbLibrary * db, guLyricSearch
 
 	EditorSizer->Add( m_UpdateCheckBox, 0, wxEXPAND|wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	m_SetupButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_search_engine ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_SetupButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search_engine ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_SetupButton->SetToolTip( _( "Configure lyrics preferences" ) );
 	EditorSizer->Add( m_SetupButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP, 5 );
 
-	m_ReloadButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_search_again ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_ReloadButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search_again ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_ReloadButton->SetToolTip( _( "Search for lyrics" ) );
     m_ReloadButton->Enable( false );
 	EditorSizer->Add( m_ReloadButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP, 5 );
 
-	m_EditButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_EditButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_EditButton->SetToolTip( _( "Edit the lyrics" ) );
 	m_EditButton->Enable( false );
 	EditorSizer->Add( m_EditButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP, 5 );
 
-	m_SaveButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_doc_save ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_SaveButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_SaveButton->Enable( false );
 	m_SaveButton->SetToolTip( _( "Save the lyrics" ) );
 	EditorSizer->Add( m_SaveButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP, 5 );
 
-	m_WebSearchButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_search ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_WebSearchButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_WebSearchButton->Enable( false );
 	m_WebSearchButton->SetToolTip( _( "Search the lyrics on the web" ) );
 	EditorSizer->Add( m_WebSearchButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
@@ -283,7 +283,7 @@ void guLyricsPanel::CreateContextMenu( wxMenu * menu )
 {
     wxMenuItem * MenuItem;
     MenuItem = new wxMenuItem( menu, ID_LYRICS_COPY, _( "Copy to Clipboard" ), _( "Copy the content of the lyric to clipboard" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_copy ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_copy ) );
     menu->Append( MenuItem );
 
     wxTheClipboard->UsePrimarySelection( false );
@@ -304,7 +304,7 @@ void guLyricsPanel::CreateContextMenu( wxMenu * menu )
     menu->AppendSeparator();
 
     MenuItem = new wxMenuItem( menu, ID_LYRICS_PRINT, _( "Print" ), _( "Print the content of the lyrics" ) );
-    //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_ ) );
+    //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_ ) );
     menu->Append( MenuItem );
 }
 
@@ -2151,11 +2151,11 @@ guLyricSourceEditor::guLyricSourceEditor( wxWindow * parent, guLyricSource * lyr
 
 	wxBoxSizer * ReplaceBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_ReplaceAdd = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_ReplaceAdd = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_ReplaceAdd->Enable( lyricsource->Type() != guLYRIC_SOURCE_TYPE_EMBEDDED );
 	ReplaceBtnSizer->Add( m_ReplaceAdd, 0, wxTOP|wxBOTTOM|wxRIGHT, 5 );
 
-	m_ReplaceDel = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_ReplaceDel = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_ReplaceDel->Enable( false );
 	ReplaceBtnSizer->Add( m_ReplaceDel, 0, wxBOTTOM|wxRIGHT, 5 );
 
@@ -2184,10 +2184,10 @@ guLyricSourceEditor::guLyricSourceEditor( wxWindow * parent, guLyricSource * lyr
 
         wxBoxSizer * ExtractBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-        m_ExtractAdd = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+        m_ExtractAdd = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
         ExtractBtnSizer->Add( m_ExtractAdd, 0, wxTOP|wxBOTTOM|wxRIGHT, 5 );
 
-        m_ExtractDel = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+        m_ExtractDel = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
         m_ExtractDel->Enable( false );
         ExtractBtnSizer->Add( m_ExtractDel, 0, wxBOTTOM|wxRIGHT, 5 );
 
@@ -2214,10 +2214,10 @@ guLyricSourceEditor::guLyricSourceEditor( wxWindow * parent, guLyricSource * lyr
 
         wxBoxSizer * ExcludeBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-        m_ExcludeAdd = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+        m_ExcludeAdd = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
         ExcludeBtnSizer->Add( m_ExcludeAdd, 0, wxTOP|wxBOTTOM|wxRIGHT, 5 );
 
-        m_ExcludeDel = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+        m_ExcludeDel = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
         m_ExcludeDel->Enable( false );
         ExcludeBtnSizer->Add( m_ExcludeDel, 0, wxBOTTOM|wxRIGHT, 5 );
 
@@ -2238,10 +2238,10 @@ guLyricSourceEditor::guLyricSourceEditor( wxWindow * parent, guLyricSource * lyr
         wxBoxSizer* NotFoundBtnSizer;
         NotFoundBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-        m_NotFoundAdd = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+        m_NotFoundAdd = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
         NotFoundBtnSizer->Add( m_NotFoundAdd, 0, wxTOP|wxBOTTOM|wxRIGHT, 5 );
 
-        m_NotFoundDel = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+        m_NotFoundDel = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
         m_NotFoundDel->Enable( false );
         NotFoundBtnSizer->Add( m_NotFoundDel, 0, wxBOTTOM|wxRIGHT, 5 );
 

--- a/src/MainApp.cpp
+++ b/src/MainApp.cpp
@@ -382,8 +382,7 @@ bool guMainApp::OnInit()
     guMainFrame * Frame = new guMainFrame( 0, m_DbCache );
     SetTopWindow( Frame );
     //Frame->SetMainFrame();
-    wxIcon MainIcon;
-    MainIcon.CopyFromBitmap( guImage( guIMAGE_INDEX_guayadeque ) );
+    wxIcon MainIcon( guNS_Image::GetIcon( guIMAGE_INDEX_guayadeque ) );
     Frame->SetIcon( MainIcon );
 
     // If Minimize is enabled minimized or hide it if Taskbar Icon is enabled

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -159,9 +159,7 @@ guMainFrame::guMainFrame( wxWindow * parent, guDbCache * dbcache )
     m_LyricSearchContext = NULL;
 
     //
-    wxImage TaskBarIcon( guImage( guIMAGE_INDEX_guayadeque_taskbar ) );
-    TaskBarIcon.ConvertAlphaToMask();
-    m_AppIcon.CopyFromBitmap( TaskBarIcon );
+    m_AppIcon = guNS_Image::GetIcon( guIMAGE_INDEX_guayadeque_taskbar );
 
     //
     m_VolumeMonitor = new guGIO_VolumeMonitor( this );
@@ -4515,7 +4513,7 @@ void guMainFrame::CreateCopyToMenu( wxMenu * menu )
             }
 
             MenuItem = new wxMenuItem( SubMenu, ID_COPYTO_BASE + guCOPYTO_DEVICE_BASE + Index, MediaViewer->GetName(), _( "Copy the current selected songs to a directory or device" ) );
-            //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_copy ) );
+            //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_copy ) );
             SubMenu->Append( MenuItem );
         }
     }

--- a/src/MediaViewer.cpp
+++ b/src/MediaViewer.cpp
@@ -218,19 +218,19 @@ void guMediaViewer::CreateControls( void )
         FilterNames.Add( unescape_configlist_str( m_DynFilterArray[ Index ].BeforeFirst( wxT( ':' ) ) ) );
     }
 
-    m_LibrarySelButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_mv_library ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_LibrarySelButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_mv_library ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_LibrarySelButton->SetToolTip( _( "Library view" ) );
     TopSizer->Add( m_LibrarySelButton, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxTOP|wxBOTTOM, 5 );
 
-    m_AlbumBrowserSelButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_mv_albumbrowser ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_AlbumBrowserSelButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_mv_albumbrowser ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_AlbumBrowserSelButton->SetToolTip( _( "Album Browser view" ) );
     TopSizer->Add( m_AlbumBrowserSelButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM, 5 );
 
-    m_TreeViewSelButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_mv_treeview ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_TreeViewSelButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_mv_treeview ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_TreeViewSelButton->SetToolTip( _( "Tree view" ) );
     TopSizer->Add( m_TreeViewSelButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM, 5 );
 
-    m_PlaylistsSelButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_mv_playlists ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_PlaylistsSelButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_mv_playlists ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_PlaylistsSelButton->SetToolTip( _( "Playlists" ) );
     TopSizer->Add( m_PlaylistsSelButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxRIGHT, 5 );
 
@@ -246,16 +246,16 @@ void guMediaViewer::CreateControls( void )
     //m_FilterChoice->SetMinSize( wxSize( 100, -1 ) );
     m_FiltersSizer->Add( m_FilterChoice, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxLEFT, 5 );
 
-    m_AddFilterButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_AddFilterButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_AddFilterButton->SetToolTip( _( "Add a new album browser filter" ) );
     m_FiltersSizer->Add( m_AddFilterButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM, 5 );
 
-    m_DelFilterButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_DelFilterButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_DelFilterButton->SetToolTip( _( "Delete the current selected filter" ) );
     m_DelFilterButton->Enable( FilterSelected > 0 );
     m_FiltersSizer->Add( m_DelFilterButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM, 5 );
 
-    m_EditFilterButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_EditFilterButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_EditFilterButton->SetToolTip( _( "Edit the current selected filter" ) );
     m_EditFilterButton->Enable( FilterSelected > 0 );
     m_FiltersSizer->Add( m_EditFilterButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxRIGHT, 5 );

--- a/src/NewChannel.cpp
+++ b/src/NewChannel.cpp
@@ -106,11 +106,11 @@ guNewPodcastChannelSelector::guNewPodcastChannelSelector( wxWindow * parent ) :
 	m_DirectoryInfoStaticText->Wrap( -1 );
 	DirectoryTopSizer->Add( m_DirectoryInfoStaticText, 1, wxALIGN_CENTER_VERTICAL|wxRIGHT|wxLEFT, 5 );
 
-	m_FilterDirectory = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_search ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_FilterDirectory = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_FilterDirectory->SetToolTip( _( "Search in the podcast directory" ) );
 	DirectoryTopSizer->Add( m_FilterDirectory, 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 5 );
 
-	m_DirectoryReload = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_reload ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_DirectoryReload = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_reload ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_DirectoryReload->SetToolTip( _( "Refresh the podcast directory list" ) );
 	DirectoryTopSizer->Add( m_DirectoryReload, 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 5 );
 

--- a/src/OnlineLinks.cpp
+++ b/src/OnlineLinks.cpp
@@ -56,7 +56,7 @@ void AddOnlineLinksMenu( wxMenu * Menu )
                 }
                 else
                 {
-                    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_search ) );
+                    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_search ) );
                 }
                 SubMenu->Append( MenuItem );
             }

--- a/src/PLSoListBox.cpp
+++ b/src/PLSoListBox.cpp
@@ -165,7 +165,7 @@ void guPLSoListBox::CreateContextMenu( wxMenu * Menu ) const
         if( ( m_PLTypes.Count() == 1 ) && ( m_PLTypes[ 0 ] == guPLAYLIST_TYPE_STATIC ) )
         {
             MenuItem = new wxMenuItem( Menu, ID_TRACKS_DELETE, _( "Remove from Playlist" ), _( "Delete the current selected tracks" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_del ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ) );
             Menu->Insert( InsertPosition, MenuItem );
         }
     }

--- a/src/PcListBox.cpp
+++ b/src/PcListBox.cpp
@@ -109,14 +109,14 @@ void guPcListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_PLAYCOUNT_PLAY,
                             wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play current selected tracks" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( Menu, ID_PLAYCOUNT_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add current selected tracks to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -125,21 +125,21 @@ void guPcListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( EnqueueMenu, ID_PLAYCOUNT_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_PLAYCOUNT_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_PLAYCOUNT_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -154,7 +154,7 @@ void guPcListBox::CreateContextMenu( wxMenu * Menu ) const
             MenuItem = new wxMenuItem( Menu, ID_PLAYCOUNT_EDITTRACKS,
                                 wxString( _( "Edit Songs" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                                 _( "Edit the selected tracks" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu->Append( MenuItem );
         }
 
@@ -163,7 +163,7 @@ void guPcListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_PLAYCOUNT_SAVETOPLAYLIST,
                                 wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                                 _( "Save the selected tracks to playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         if( ContextMenuFlags & guCONTEXTMENU_COPY_TO )

--- a/src/PlayList.cpp
+++ b/src/PlayList.cpp
@@ -115,10 +115,10 @@ guPlayList::guPlayList( wxWindow * parent, guDbLibrary * db, guPlayerPanel * pla
 //    if( ( size_t ) m_CurItem > m_Items.Count() )
 //        m_CurItem = wxNOT_FOUND;
 
-    m_PlayBitmap = new wxBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
-    m_StopBitmap = new wxBitmap( guImage( guIMAGE_INDEX_player_tiny_red_stop ) );
-    m_NormalStar   = new wxBitmap( guImage( guIMAGE_INDEX_star_normal_tiny ) );
-    m_SelectStar = new wxBitmap( guImage( guIMAGE_INDEX_star_highlight_tiny ) );
+    m_PlayBitmap = new wxBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
+    m_StopBitmap = new wxBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_red_stop ) );
+    m_NormalStar   = new wxBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_star_normal_tiny ) );
+    m_SelectStar = new wxBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_star_highlight_tiny ) );
 
 //    Connect( wxEVT_COMMAND_LIST_BEGIN_DRAG, wxMouseEventHandler( guPlayList::OnBeginDrag ), NULL, this );
     Connect( ID_PLAYER_PLAYLIST_CLEAR, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( guPlayList::OnClearClicked ), NULL, this );
@@ -1530,13 +1530,13 @@ void guPlayList::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_PLAYER_PLAYLIST_EDITLABELS,
                             wxString( _( "Edit Labels" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITLABELS ),
                             _( "Edit the current selected tracks labels" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tags ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tags ) );
     Menu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( Menu, ID_PLAYER_PLAYLIST_EDITTRACKS,
                             wxString( _( "Edit Songs" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                             _( "Edit the current selected songs" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit ) );
     Menu->Append( MenuItem );
 
     Menu->AppendSeparator();
@@ -1571,7 +1571,7 @@ void guPlayList::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_PLAYER_PLAYLIST_SEARCH,
                             wxString( _( "Search" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SEARCH ),
                             _( "Search a track in the playlist by name" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_search ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ) );
     Menu->Append( MenuItem );
 
     Menu->AppendSeparator();
@@ -1579,7 +1579,7 @@ void guPlayList::CreateContextMenu( wxMenu * Menu ) const
 //    MenuItem = new wxMenuItem( Menu, ID_PLAYER_PLAYLIST_STOP_ATEND,
 //                            wxString( _( "Stop at end" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_STOP_ATEND),
 //                            _( "Stop after current playing or selected track" ) );
-//    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_stop ) );
+//    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_stop ) );
 //    Menu->Append( MenuItem );
 //
 //    Menu->AppendSeparator();
@@ -1587,7 +1587,7 @@ void guPlayList::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_PLAYER_PLAYLIST_SAVE,
                         wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                         _( "Save the selected tracks to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_doc_save ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_doc_save ) );
     Menu->Append( MenuItem );
 
     if( SelCount == 1 )
@@ -1604,7 +1604,7 @@ void guPlayList::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_PLAYER_PLAYLIST_CLEAR,
                             wxString( _( "Clear Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_CLEAR ),
                             _( "Remove all tracks from playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_clear ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_clear ) );
     Menu->Append( MenuItem );
 
     if( SelCount )
@@ -1612,7 +1612,7 @@ void guPlayList::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_PLAYER_PLAYLIST_REMOVE,
                             _( "Remove from Playlist" ),
                             _( "Remove the selected tracks from playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_delete ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_delete ) );
         Menu->Append( MenuItem );
 
         Menu->AppendSeparator();
@@ -1620,13 +1620,13 @@ void guPlayList::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_PLAYER_PLAYLIST_DELETE_LIBRARY,
                             _( "Remove from Library" ),
                             _( "Remove the selected tracks from library" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_PLAYER_PLAYLIST_DELETE_DRIVE,
                             _( "Delete from Drive" ),
                             _( "Remove the selected tracks from drive" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
         Menu->Append( MenuItem );
     }
 

--- a/src/PlayListPanel.cpp
+++ b/src/PlayListPanel.cpp
@@ -73,8 +73,8 @@ guPLNamesTreeCtrl::guPLNamesTreeCtrl( wxWindow * parent, guDbLibrary * db, guPla
 
     m_PlayListPanel = playlistpanel;
     m_ImageList = new wxImageList();
-    m_ImageList->Add( wxBitmap( guImage( guIMAGE_INDEX_track ) ) );
-    m_ImageList->Add( wxBitmap( guImage( guIMAGE_INDEX_system_run ) ) );
+    m_ImageList->Add( wxBitmap( guNS_Image::GetImage( guIMAGE_INDEX_track ) ) );
+    m_ImageList->Add( wxBitmap( guNS_Image::GetImage( guIMAGE_INDEX_system_run ) ) );
 
     AssignImageList( m_ImageList );
 
@@ -221,13 +221,13 @@ void guPLNamesTreeCtrl::OnContextMenu( wxTreeEvent &event )
         if( ItemData )
         {
             MenuItem = new wxMenuItem( &Menu, ID_PLAYLIST_PLAY, _( "Play" ), _( "Play current selected songs" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
             Menu.Append( MenuItem );
 
             MenuItem = new wxMenuItem( &Menu, ID_PLAYLIST_ENQUEUE_AFTER_ALL,
                                 wxString( _( "Enqueue" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                                 _( "Add current selected songs to the playlist" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_add ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_add ) );
             Menu.Append( MenuItem );
 
             wxMenu * EnqueueMenu = new wxMenu();
@@ -235,19 +235,19 @@ void guPLNamesTreeCtrl::OnContextMenu( wxTreeEvent &event )
             MenuItem = new wxMenuItem( EnqueueMenu, ID_PLAYLIST_ENQUEUE_AFTER_TRACK,
                                     wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                                     _( "Add current selected tracks to playlist after the current track" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
             EnqueueMenu->Append( MenuItem );
 
             MenuItem = new wxMenuItem( EnqueueMenu, ID_PLAYLIST_ENQUEUE_AFTER_ALBUM,
                                     wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                                     _( "Add current selected tracks to playlist after the current album" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
             EnqueueMenu->Append( MenuItem );
 
             MenuItem = new wxMenuItem( EnqueueMenu, ID_PLAYLIST_ENQUEUE_AFTER_ARTIST,
                                     wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                                     _( "Add current selected tracks to playlist after the current artist" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
             EnqueueMenu->Append( MenuItem );
 
             Menu.Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -257,19 +257,19 @@ void guPLNamesTreeCtrl::OnContextMenu( wxTreeEvent &event )
     }
 
     MenuItem = new wxMenuItem( &Menu, ID_PLAYLIST_NEWPLAYLIST, _( "New Dynamic Playlist" ), _( "Create a new dynamic playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_doc_new ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_doc_new ) );
     Menu.Append( MenuItem );
 
     Menu.AppendSeparator();
 
     MenuItem = new wxMenuItem( &Menu, ID_PLAYLIST_IMPORT, _( "Import" ), _( "Import a playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_doc_new ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_doc_new ) );
     Menu.Append( MenuItem );
 
     if( ItemData )
     {
         MenuItem = new wxMenuItem( &Menu, ID_PLAYLIST_EXPORT, _( "Export" ), _( "Export the playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_doc_save ) );
         Menu.Append( MenuItem );
 
         Menu.AppendSeparator();
@@ -279,31 +279,31 @@ void guPLNamesTreeCtrl::OnContextMenu( wxTreeEvent &event )
             if( ItemData->GetType() == guPLAYLIST_TYPE_DYNAMIC )
             {
                 MenuItem = new wxMenuItem( &Menu, ID_PLAYLIST_EDIT, _( "Edit" ), _( "Edit the selected playlist" ) );
-                MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit ) );
+                MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit ) );
                 Menu.Append( MenuItem );
 
                 MenuItem = new wxMenuItem( &Menu, ID_TRACKS_SAVETOPLAYLIST, _( "Save to Playlist" ), _( "Save the selected playlist as a Static Playlist" ) );
-                MenuItem->SetBitmap( guImage( guIMAGE_INDEX_doc_save ) );
+                MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_doc_save ) );
                 Menu.Append( MenuItem );
             }
 
             MenuItem = new wxMenuItem( &Menu, ID_PLAYLIST_RENAME, _( "Rename" ), _( "Change the name of the selected playlist" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit ) );
             Menu.Append( MenuItem );
         }
 
         MenuItem = new wxMenuItem( &Menu, ID_PLAYLIST_DELETE, _( "Delete" ), _( "Delete the selected playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_edit_delete ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_edit_delete ) );
         Menu.Append( MenuItem );
 
         Menu.AppendSeparator();
 
         MenuItem = new wxMenuItem( &Menu, ID_MAINFRAME_SET_ALLOW_PLAYLIST, _( "Set as Allow Filter" ), _( "Set this playlist as the allow filter" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_accept ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_accept ) );
         Menu.Append( MenuItem );
 
         MenuItem = new wxMenuItem( &Menu, ID_MAINFRAME_SET_DENY_PLAYLIST, _( "Set as Deny Filter" ), _( "Delete the selected playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_filter ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_filter ) );
         Menu.Append( MenuItem );
 
         Menu.AppendSeparator();

--- a/src/PlayerPanel.cpp
+++ b/src/PlayerPanel.cpp
@@ -171,27 +171,27 @@ guPlayerPanel::guPlayerPanel( wxWindow * parent, guDbLibrary * db,
 
 	wxBoxSizer * PlayerBtnSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	//m_PrevTrackButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_player_normal_prev ), wxDefaultPosition, wxDefaultSize, 0 ); //wxBU_AUTODRAW );
-	m_PrevTrackButton = new guRoundButton( this, guImage( guIMAGE_INDEX_player_normal_prev ), guImage( guIMAGE_INDEX_player_highlight_prev ), 0 );
+	//m_PrevTrackButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_prev ), wxDefaultPosition, wxDefaultSize, 0 ); //wxBU_AUTODRAW );
+	m_PrevTrackButton = new guRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_normal_prev ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_prev ), 0 );
 	m_PrevTrackButton->SetToolTip( _( "Go to the playlist previous track" ) );
 	PlayerBtnSizer->Add( m_PrevTrackButton, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxTOP|wxBOTTOM, guPLAYER_ICONS_SEPARATOR );
 
-	//m_PlayButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_player_normal_play ), wxDefaultPosition, wxDefaultSize, 0 );
-	m_PlayButton = new guRoundButton( this, guImage( guIMAGE_INDEX_player_normal_play ), guImage( guIMAGE_INDEX_player_highlight_play ), 0 );
+	//m_PlayButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_play ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_PlayButton = new guRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_normal_play ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_play ), 0 );
 	m_PlayButton->SetToolTip( _( "Play or pause the current track" ) );
 	PlayerBtnSizer->Add( m_PlayButton, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxTOP|wxBOTTOM, guPLAYER_ICONS_SEPARATOR );
 
-	//m_NextTrackButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_player_normal_next ), wxDefaultPosition, wxDefaultSize, 0 );
-	m_NextTrackButton = new guRoundButton( this, guImage( guIMAGE_INDEX_player_normal_next ), guImage( guIMAGE_INDEX_player_highlight_next ), 0 );
+	//m_NextTrackButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_next ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_NextTrackButton = new guRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_normal_next ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_next ), 0 );
 	m_NextTrackButton->SetToolTip( _( "Go to the playlist next track" ) );
 	PlayerBtnSizer->Add( m_NextTrackButton, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxTOP|wxBOTTOM, guPLAYER_ICONS_SEPARATOR );
 
-	//m_StopButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_player_normal_stop ), wxDefaultPosition, wxDefaultSize, 0 );
-	m_StopButton = new guRoundButton( this, guImage( guIMAGE_INDEX_player_normal_stop ), guImage( guIMAGE_INDEX_player_highlight_stop ), 0 );
+	//m_StopButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_stop ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_StopButton = new guRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_normal_stop ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_stop ), 0 );
 	m_StopButton->SetToolTip( _( "Stop playing" ) );
 	PlayerBtnSizer->Add( m_StopButton, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxTOP|wxBOTTOM|wxRIGHT, guPLAYER_ICONS_SEPARATOR );
 
-    m_RecordButton = new guToggleRoundButton( this, guImage( guIMAGE_INDEX_player_light_record ), guImage( guIMAGE_INDEX_player_normal_record ), guImage( guIMAGE_INDEX_player_highlight_record ) );
+    m_RecordButton = new guToggleRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_light_record ), guNS_Image::GetImage( guIMAGE_INDEX_player_normal_record ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_record ) );
     m_RecordButton->SetToolTip( _( "Record to file" ) );
     m_RecordButton->Enable( false );
     m_RecordButton->Show( Config->ReadBool( wxT( "Enabled" ), false, wxT( "record" ) ) );
@@ -199,20 +199,20 @@ guPlayerPanel::guPlayerPanel( wxWindow * parent, guDbLibrary * db,
 
 	PlayerBtnSizer->Add( guPLAYER_ICONS_GROUPSEPARATOR, 0, 0, wxEXPAND, 5 );
 
-	//m_VolumeButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_player_normal_vol_mid ), wxDefaultPosition, wxDefaultSize, 0 );
-	m_VolumeButton = new guRoundButton( this, guImage( guIMAGE_INDEX_player_normal_vol_mid ), guImage( guIMAGE_INDEX_player_highlight_vol_mid ), 0 );
+	//m_VolumeButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_vol_mid ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_VolumeButton = new guRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_normal_vol_mid ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_vol_mid ), 0 );
     m_VolumeButton->SetToolTip( _( "Volume" ) + wxString::Format( wxT( " %i%%" ), ( int ) SavedVol ) );
 	PlayerBtnSizer->Add( m_VolumeButton, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxTOP|wxBOTTOM, guPLAYER_ICONS_SEPARATOR );
 
-	//m_EqualizerButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_player_normal_equalizer ), wxDefaultPosition, wxDefaultSize, 0 );
-	m_EqualizerButton = new guRoundButton( this, guImage( guIMAGE_INDEX_player_normal_equalizer ), guImage( guIMAGE_INDEX_player_highlight_equalizer ), 0 );
+	//m_EqualizerButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_equalizer ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_EqualizerButton = new guRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_normal_equalizer ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_equalizer ), 0 );
 	m_EqualizerButton->SetToolTip( _( "Show the equalizer" ) );
 	PlayerBtnSizer->Add( m_EqualizerButton, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxTOP|wxBOTTOM|wxRIGHT, guPLAYER_ICONS_SEPARATOR );
 
 	PlayerBtnSizer->Add( guPLAYER_ICONS_GROUPSEPARATOR, 0, 0, wxEXPAND, 5 );
 
-	//m_SmartPlayButton = new wxToggleBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_player_normal_smart ), wxDefaultPosition, wxDefaultSize, 0 );
-	m_SmartPlayButton = new guToggleRoundButton( this, guImage( guIMAGE_INDEX_player_light_smart ), guImage( guIMAGE_INDEX_player_normal_smart ), guImage( guIMAGE_INDEX_player_highlight_smart ) );
+	//m_SmartPlayButton = new wxToggleBitmapButton( this, wxID_ANY, guNS_Image::GetImage( guIMAGE_INDEX_player_normal_smart ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_SmartPlayButton = new guToggleRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_light_smart ), guNS_Image::GetImage( guIMAGE_INDEX_player_normal_smart ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_smart ) );
 	//m_SmartPlayButton->SetToolTip( _( "Add tracks to the playlist based on LastFM" ) );
     wxString TipText = _( "Smart Play: " );
     if( !m_PlaySmart )
@@ -228,7 +228,7 @@ guPlayerPanel::guPlayerPanel( wxWindow * parent, guDbLibrary * db,
 	m_SmartPlayButton->SetValue( m_PlaySmart );
 	PlayerBtnSizer->Add( m_SmartPlayButton, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxTOP|wxBOTTOM, guPLAYER_ICONS_SEPARATOR );
 
-	m_RepeatPlayButton = new guToggleRoundButton( this, guImage( guIMAGE_INDEX_player_light_repeat ), guImage( guIMAGE_INDEX_player_normal_repeat ), guImage( guIMAGE_INDEX_player_highlight_repeat ) );
+	m_RepeatPlayButton = new guToggleRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_light_repeat ), guNS_Image::GetImage( guIMAGE_INDEX_player_normal_repeat ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_repeat ) );
 	//m_RepeatPlayButton->SetToolTip( _( "Select the repeat mode" ) );
     TipText = _( "Repeat: " );
     if( !m_PlayLoop )
@@ -247,8 +247,8 @@ guPlayerPanel::guPlayerPanel( wxWindow * parent, guDbLibrary * db,
 	m_RepeatPlayButton->SetValue( m_PlayLoop );
 	PlayerBtnSizer->Add( m_RepeatPlayButton, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxTOP|wxBOTTOM, guPLAYER_ICONS_SEPARATOR );
 
-	//m_RandomPlayButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_player_normal_random ), wxDefaultPosition, wxDefaultSize, 0 );
-	m_RandomPlayButton = new guRoundButton( this, guImage( guIMAGE_INDEX_player_normal_random ), guImage( guIMAGE_INDEX_player_highlight_random ), 0 );
+	//m_RandomPlayButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_random ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_RandomPlayButton = new guRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_normal_random ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_random ), 0 );
 	m_RandomPlayButton->SetToolTip( _( "Randomize the tracks in playlist" ) );
 	PlayerBtnSizer->Add( m_RandomPlayButton, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxTOP|wxBOTTOM, guPLAYER_ICONS_SEPARATOR );
 
@@ -258,7 +258,7 @@ guPlayerPanel::guPlayerPanel( wxWindow * parent, guDbLibrary * db,
 	wxBoxSizer* PlayerDetailsSizer;
 	PlayerDetailsSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	m_PlayerCoverBitmap = new wxStaticBitmap( this, wxID_ANY, guImage( guIMAGE_INDEX_no_cover ), wxDefaultPosition, wxSize( 100,100 ), 0 );
+	m_PlayerCoverBitmap = new wxStaticBitmap( this, wxID_ANY, guNS_Image::GetImage( guIMAGE_INDEX_no_cover ), wxDefaultPosition, wxSize( 100,100 ), 0 );
 	//m_PlayerCoverBitmap->SetToolTip( _( "Shows the current track album cover if available" ) );
 	PlayerDetailsSizer->Add( m_PlayerCoverBitmap, 0, wxALL, 2 );
 
@@ -315,7 +315,7 @@ guPlayerPanel::guPlayerPanel( wxWindow * parent, guDbLibrary * db,
     m_Rating = new guRating( this, GURATING_STYLE_MID );
 	m_BitRateSizer->Add( m_Rating, 0, wxRIGHT|wxALIGN_CENTER_VERTICAL, 2 );
 
-//	m_LoveBanButton = new guToggleRoundButton( this, guImage( guIMAGE_INDEX_player_light_love ), guImage( guIMAGE_INDEX_player_normal_love ), guImage( guIMAGE_INDEX_player_highlight_love ) );
+//	m_LoveBanButton = new guToggleRoundButton( this, guNS_Image::GetImage( guIMAGE_INDEX_player_light_love ), guNS_Image::GetImage( guIMAGE_INDEX_player_normal_love ), guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_love ) );
 //    m_LoveBanButton->SetToolTip( _( "Love or Ban a track in AudioScrobble service" ) );
 //    m_BitRateSizer->Add( m_LoveBanButton, 0, wxEXPAND|wxRIGHT|wxLEFT|wxALIGN_CENTER_VERTICAL, 2 );
 
@@ -1485,13 +1485,13 @@ void guPlayerPanel::OnMediaState( guMediaEvent &event )
     {
         if( State == GST_STATE_PLAYING ) //guMEDIASTATE_PLAYING )
         {
-            m_PlayButton->SetBitmapLabel( guImage( guIMAGE_INDEX_player_normal_pause ) );
-            m_PlayButton->SetBitmapHover( guImage( guIMAGE_INDEX_player_highlight_pause ) );
+            m_PlayButton->SetBitmapLabel( guNS_Image::GetImage( guIMAGE_INDEX_player_normal_pause ) );
+            m_PlayButton->SetBitmapHover( guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_pause ) );
         }
         else
         {
-            m_PlayButton->SetBitmapLabel( guImage( guIMAGE_INDEX_player_normal_play ) );
-            m_PlayButton->SetBitmapHover( guImage( guIMAGE_INDEX_player_highlight_play ) );
+            m_PlayButton->SetBitmapLabel( guNS_Image::GetImage( guIMAGE_INDEX_player_normal_play ) );
+            m_PlayButton->SetBitmapHover( guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_play ) );
 
             if( State == GST_STATE_READY )
             {
@@ -1792,7 +1792,7 @@ void guPlayerPanel::OnMediaTags( guMediaEvent &event )
                 event.SetClientData( new guTrack( m_MediaSong ) );
                 wxPostEvent( m_MainFrame, event );
 
-                wxImage Image( guImage( guIMAGE_INDEX_net_radio ) );
+                wxImage Image( guNS_Image::GetImage( guIMAGE_INDEX_net_radio ) );
                 SendNotifyInfo( &Image );
             }
             GetSizer()->Layout();
@@ -1960,7 +1960,7 @@ void guPlayerPanel::SetCurrentCoverImage( wxImage * coverimage, const guSongCove
     }
     else //if( covertype == GU_SONGCOVER_NONE )
     {
-        m_MediaSong.SetCoverImage( new wxImage( guImage( guIMAGE_INDEX_no_cover ) ) );
+        m_MediaSong.SetCoverImage( new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_no_cover ) ) );
         m_MediaSong.m_CoverType = GU_SONGCOVER_NONE;
         m_MediaSong.m_CoverPath = wxEmptyString;
     }
@@ -2204,16 +2204,16 @@ void guPlayerPanel::SetPlayLoop( int playloop )
     m_PlayLoop = playloop;
 
     m_RepeatPlayButton->SetBitmapLabel( m_PlayLoop < guPLAYER_PLAYLOOP_TRACK ?
-        guImage( guIMAGE_INDEX_player_normal_repeat ) :
-        guImage( guIMAGE_INDEX_player_normal_repeat_single ) );
+        guNS_Image::GetImage( guIMAGE_INDEX_player_normal_repeat ) :
+        guNS_Image::GetImage( guIMAGE_INDEX_player_normal_repeat_single ) );
 
     m_RepeatPlayButton->SetBitmapDisabled( m_PlayLoop < guPLAYER_PLAYLOOP_TRACK ?
-        guImage( guIMAGE_INDEX_player_light_repeat ) :
-        guImage( guIMAGE_INDEX_player_light_repeat_single ) );
+        guNS_Image::GetImage( guIMAGE_INDEX_player_light_repeat ) :
+        guNS_Image::GetImage( guIMAGE_INDEX_player_light_repeat_single ) );
 
     m_RepeatPlayButton->SetBitmapHover( m_PlayLoop < guPLAYER_PLAYLOOP_TRACK ?
-        guImage( guIMAGE_INDEX_player_highlight_repeat ) :
-        guImage( guIMAGE_INDEX_player_highlight_repeat_single ) );
+        guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_repeat ) :
+        guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_repeat_single ) );
 
     m_RepeatPlayButton->SetValue( m_PlayLoop );
     if( m_PlayLoop && GetPlaySmart() )
@@ -2314,7 +2314,7 @@ void guPlayerPanel::OnPrevTrackButtonClick( wxCommandEvent& event )
 
                 m_MediaSong.m_CoverType = GU_SONGCOVER_NONE;
                 m_MediaSong.m_CoverPath = wxEmptyString;
-                wxImage * CoverImage = new wxImage( guImage( guIMAGE_INDEX_no_cover ) );
+                wxImage * CoverImage = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_no_cover ) );
                 // Cover
                 if( CoverImage )
                 {
@@ -2405,7 +2405,7 @@ void guPlayerPanel::OnNextTrackButtonClick( wxCommandEvent& event )
 
                 m_MediaSong.m_CoverType = GU_SONGCOVER_NONE;
                 m_MediaSong.m_CoverPath = wxEmptyString;
-                wxImage * CoverImage = new wxImage( guImage( guIMAGE_INDEX_no_cover ) );
+                wxImage * CoverImage = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_no_cover ) );
                 // Cover
                 if( CoverImage )
                 {
@@ -2721,16 +2721,16 @@ void guPlayerPanel::OnLoveBanButtonClick( wxCommandEvent &event )
             m_MediaSong.m_ASRating = guAS_RATING_NONE;
 
         m_LoveBanButton->SetBitmapLabel( m_MediaSong.m_ASRating < guAS_RATING_BAN ?
-            guImage( guIMAGE_INDEX_player_normal_love ) :
-            guImage( guIMAGE_INDEX_player_normal_ban ) );
+            guNS_Image::GetImage( guIMAGE_INDEX_player_normal_love ) :
+            guNS_Image::GetImage( guIMAGE_INDEX_player_normal_ban ) );
 
         m_LoveBanButton->SetBitmapDisabled( m_MediaSong.m_ASRating < guAS_RATING_BAN ?
-            guImage( guIMAGE_INDEX_player_light_love ) :
-            guImage( guIMAGE_INDEX_player_light_ban ) );
+            guNS_Image::GetImage( guIMAGE_INDEX_player_light_love ) :
+            guNS_Image::GetImage( guIMAGE_INDEX_player_light_ban ) );
 
         m_LoveBanButton->SetBitmapHover( m_MediaSong.m_ASRating < guAS_RATING_BAN ?
-            guImage( guIMAGE_INDEX_player_highlight_love ) :
-            guImage( guIMAGE_INDEX_player_highlight_ban ) );
+            guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_love ) :
+            guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_ban ) );
 
         m_LoveBanButton->SetValue( m_MediaSong.m_ASRating );
     }
@@ -2847,23 +2847,23 @@ void guPlayerPanel::SetVolume( double volume )
 
     if( m_CurVolume > 75 )
     {
-        m_VolumeButton->SetBitmapLabel( guImage( guIMAGE_INDEX_player_normal_vol_hi ) );
-        m_VolumeButton->SetBitmapHover( guImage( guIMAGE_INDEX_player_highlight_vol_hi ) );
+        m_VolumeButton->SetBitmapLabel( guNS_Image::GetImage( guIMAGE_INDEX_player_normal_vol_hi ) );
+        m_VolumeButton->SetBitmapHover( guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_vol_hi ) );
     }
     else if( m_CurVolume > 50 )
     {
-        m_VolumeButton->SetBitmapLabel( guImage( guIMAGE_INDEX_player_normal_vol_mid ) );
-        m_VolumeButton->SetBitmapHover( guImage( guIMAGE_INDEX_player_highlight_vol_mid ) );
+        m_VolumeButton->SetBitmapLabel( guNS_Image::GetImage( guIMAGE_INDEX_player_normal_vol_mid ) );
+        m_VolumeButton->SetBitmapHover( guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_vol_mid ) );
     }
     else if( m_CurVolume == 0 )
     {
-        m_VolumeButton->SetBitmapLabel( guImage( guIMAGE_INDEX_player_normal_muted ) );
-        m_VolumeButton->SetBitmapHover( guImage( guIMAGE_INDEX_player_highlight_muted ) );
+        m_VolumeButton->SetBitmapLabel( guNS_Image::GetImage( guIMAGE_INDEX_player_normal_muted ) );
+        m_VolumeButton->SetBitmapHover( guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_muted ) );
     }
     else
     {
-        m_VolumeButton->SetBitmapLabel( guImage( guIMAGE_INDEX_player_normal_vol_low ) );
-        m_VolumeButton->SetBitmapHover( guImage( guIMAGE_INDEX_player_highlight_vol_low ) );
+        m_VolumeButton->SetBitmapLabel( guNS_Image::GetImage( guIMAGE_INDEX_player_normal_vol_low ) );
+        m_VolumeButton->SetBitmapHover( guNS_Image::GetImage( guIMAGE_INDEX_player_highlight_vol_low ) );
     }
     m_VolumeButton->Refresh();
     m_LastVolume = m_CurVolume;
@@ -3232,12 +3232,12 @@ guUpdatePlayerCoverThread::ExitCode guUpdatePlayerCoverThread::Entry()
     }
     else if( m_CurrentTrack->m_Type == guTRACK_TYPE_RADIOSTATION )
     {
-        CoverImage = new wxImage( guImage( guIMAGE_INDEX_net_radio ) );
+        CoverImage = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_net_radio ) );
         m_CurrentTrack->m_CoverType = GU_SONGCOVER_RADIO;
     }
     else if( m_CurrentTrack->m_Type == guTRACK_TYPE_PODCAST )
     {
-        CoverImage = new wxImage( guImage( guIMAGE_INDEX_podcast ) );
+        CoverImage = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_podcast ) );
         m_CurrentTrack->m_CoverType = GU_SONGCOVER_PODCAST;
     }
     else if( m_CurrentTrack->m_MediaViewer )
@@ -3276,7 +3276,7 @@ guUpdatePlayerCoverThread::ExitCode guUpdatePlayerCoverThread::Entry()
         if( m_CurrentTrack->m_CoverPath.IsEmpty() || !wxFileExists( m_CurrentTrack->m_CoverPath ) )
         {
             //printf( "No coverpath set\n" );
-            CoverImage = new wxImage( guImage( guIMAGE_INDEX_no_cover ) );
+            CoverImage = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_no_cover ) );
             m_CurrentTrack->m_CoverType = GU_SONGCOVER_NONE;
             m_CurrentTrack->m_CoverPath = wxEmptyString;
         }

--- a/src/PodcastsPanel.cpp
+++ b/src/PodcastsPanel.cpp
@@ -935,7 +935,7 @@ guPodcastPanel::guPodcastPanel( wxWindow * parent, guDbPodcasts * db, guMainFram
 	m_DetailFlexGridSizer->SetFlexibleDirection( wxBOTH );
 	m_DetailFlexGridSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
-	m_DetailImage = new wxStaticBitmap( m_DetailScrolledWindow, wxID_ANY, guImage( guIMAGE_INDEX_mid_podcast ), wxDefaultPosition, wxSize( 60,60 ), 0 );
+	m_DetailImage = new wxStaticBitmap( m_DetailScrolledWindow, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_mid_podcast ), wxDefaultPosition, wxSize( 60,60 ), 0 );
 	m_DetailFlexGridSizer->Add( m_DetailImage, 0, wxALL, 5 );
 
 	m_DetailChannelTitle = new wxStaticText( m_DetailScrolledWindow, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
@@ -1484,7 +1484,7 @@ void guPodcastPanel::UpdateChannelInfo( int itemid )
                 m_DetailImage->SetBitmap( PodcastImage );
             }
             else
-                m_DetailImage->SetBitmap( guBitmap( guIMAGE_INDEX_mid_podcast ) );
+                m_DetailImage->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_mid_podcast ) );
         }
 
         m_DetailChannelTitle->SetLabel( PodcastChannel.m_Title );
@@ -1497,7 +1497,7 @@ void guPodcastPanel::UpdateChannelInfo( int itemid )
     }
     else
     {
-        m_DetailImage->SetBitmap( guBitmap( guIMAGE_INDEX_mid_podcast ) );
+        m_DetailImage->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_mid_podcast ) );
         m_DetailChannelTitle->SetLabel( wxEmptyString );
         m_DetailDescText->SetLabel( wxEmptyString );
         m_DetailAuthorText->SetLabel( wxEmptyString );
@@ -1742,25 +1742,25 @@ void guChannelsListBox::CreateContextMenu( wxMenu * Menu ) const
     int SelCount = GetSelectedCount();
 
     MenuItem = new wxMenuItem( Menu, ID_PODCASTS_CHANNEL_ADD, _( "New Channel" ), _( "Add a new podcast channel" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu->Append( MenuItem );
 
     if( SelCount )
     {
         MenuItem = new wxMenuItem( Menu, ID_PODCASTS_CHANNEL_DEL, _( "Delete" ), _( "delete this podcast channels and all its items" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
         Menu->Append( MenuItem );
 
         Menu->AppendSeparator();
 
         MenuItem = new wxMenuItem( Menu, ID_PODCASTS_CHANNEL_UPDATE, _( "Update" ), _( "Update the podcast items of the selected channels" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         if( SelCount == 1 )
         {
             MenuItem = new wxMenuItem( Menu, ID_PODCASTS_CHANNEL_PROPERTIES, _( "Properties" ), _( "Edit the podcast channel" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu->Append( MenuItem );
         }
 
@@ -1813,11 +1813,11 @@ guPodcastListBox::guPodcastListBox( wxWindow * parent, guDbPodcasts * db ) :
 
     // Construct the images for the status
     m_Images[ guPODCAST_STATUS_NORMAL ] = NULL;
-    m_Images[ guPODCAST_STATUS_PENDING ] = new wxImage( guImage( guIMAGE_INDEX_tiny_status_pending ) );
-    m_Images[ guPODCAST_STATUS_DOWNLOADING ] = new wxImage( guImage( guIMAGE_INDEX_tiny_doc_save ) );
-    m_Images[ guPODCAST_STATUS_READY ] = new wxImage( guImage( guIMAGE_INDEX_tiny_accept ) );
-    m_Images[ guPODCAST_STATUS_DELETED ] = new wxImage( guImage( guIMAGE_INDEX_tiny_status_error ) );
-    m_Images[ guPODCAST_STATUS_ERROR ] = new wxImage( guImage( guIMAGE_INDEX_tiny_status_error ) );
+    m_Images[ guPODCAST_STATUS_PENDING ] = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_tiny_status_pending ) );
+    m_Images[ guPODCAST_STATUS_DOWNLOADING ] = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_tiny_doc_save ) );
+    m_Images[ guPODCAST_STATUS_READY ] = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_tiny_accept ) );
+    m_Images[ guPODCAST_STATUS_DELETED ] = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_tiny_status_error ) );
+    m_Images[ guPODCAST_STATUS_ERROR ] = new wxImage( guNS_Image::GetImage( guIMAGE_INDEX_tiny_status_error ) );
 
     int ColId;
     wxString ColName;
@@ -2048,13 +2048,13 @@ void guPodcastListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_PODCASTS_ITEM_PLAY,
                                 wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                                 _( "Play current selected songs" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_PODCASTS_ITEM_ENQUEUE_AFTER_ALL,
                                 wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                                 _( "Add current selected songs to playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         Menu->Append( MenuItem );
 
         wxMenu * EnqueueMenu = new wxMenu();
@@ -2062,19 +2062,19 @@ void guPodcastListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( EnqueueMenu, ID_PODCASTS_ITEM_ENQUEUE_AFTER_TRACK,
                                 wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                                 _( "Add current selected tracks to playlist after the current track" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_PODCASTS_ITEM_ENQUEUE_AFTER_ALBUM,
                                 wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                                 _( "Add current selected tracks to playlist after the current album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_PODCASTS_ITEM_ENQUEUE_AFTER_ARTIST,
                                 wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                                 _( "Add current selected tracks to playlist after the current artist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
 
         Menu->Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -2082,13 +2082,13 @@ void guPodcastListBox::CreateContextMenu( wxMenu * Menu ) const
         Menu->AppendSeparator();
 
         MenuItem = new wxMenuItem( Menu, ID_PODCASTS_ITEM_DEL, _( "Delete" ), _( "Delete the current selected podcasts" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
         Menu->Append( MenuItem );
 
         Menu->AppendSeparator();
 
         MenuItem = new wxMenuItem( Menu, ID_PODCASTS_ITEM_DOWNLOAD, _( "Download" ), _( "Download the current selected podcasts" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         Menu->AppendSeparator();
@@ -2100,7 +2100,7 @@ void guPodcastListBox::CreateContextMenu( wxMenu * Menu ) const
     {
         wxMenuItem * MenuItem;
         MenuItem = new wxMenuItem( Menu, wxID_ANY, _( "No selected items..." ), _( "Copy the current selected podcasts to a directory or device" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_status_error ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_status_error ) );
         Menu->Append( MenuItem );
     }
 }

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -197,21 +197,21 @@ guPrefDialog::guPrefDialog( wxWindow* parent, guDbLibrary * db, int pagenum )
 	m_MainNotebook = new wxListbook( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBK_LEFT );
 
     m_ImageList = new wxImageList( 32, 32 );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_general ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_library ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_playback ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_crossfader ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_record ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_last_fm ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_lyrics ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_online_services ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_podcasts ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_jamendo ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_magnatune ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_links ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_commands ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_copy_to ) );
-    m_ImageList->Add( guImage( guIMAGE_INDEX_pref_accelerators ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_general ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_library ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_playback ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_crossfader ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_record ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_last_fm ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_lyrics ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_online_services ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_podcasts ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_jamendo ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_magnatune ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_links ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_commands ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_copy_to ) );
+    m_ImageList->Add( guNS_Image::GetImage( guIMAGE_INDEX_pref_accelerators ) );
     m_MainNotebook->AssignImageList( m_ImageList );
 
 
@@ -753,18 +753,18 @@ void guPrefDialog::BuildLibraryPage( void )
 
 	wxBoxSizer * LibCollectBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_LibCollectAddBtn = new wxBitmapButton( LibCollectPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LibCollectAddBtn = new wxBitmapButton( LibCollectPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	LibCollectBtnSizer->Add( m_LibCollectAddBtn, 0, wxTOP, 5 );
 
-	m_LibCollectUpBtn = new wxBitmapButton( LibCollectPanel, wxID_ANY, guImage( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LibCollectUpBtn = new wxBitmapButton( LibCollectPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LibCollectUpBtn->Enable( false );
 	LibCollectBtnSizer->Add( m_LibCollectUpBtn, 0, 0, 5 );
 
-	m_LibCollectDownBtn = new wxBitmapButton( LibCollectPanel, wxID_ANY, guImage( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LibCollectDownBtn = new wxBitmapButton( LibCollectPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LibCollectDownBtn->Enable( false );
 	LibCollectBtnSizer->Add( m_LibCollectDownBtn, 0, 0, 5 );
 
-	m_LibCollectDelBtn = new wxBitmapButton( LibCollectPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LibCollectDelBtn = new wxBitmapButton( LibCollectPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LibCollectDelBtn->Enable( false );
 	LibCollectBtnSizer->Add( m_LibCollectDelBtn, 0, wxBOTTOM, 5 );
 
@@ -792,11 +792,11 @@ void guPrefDialog::BuildLibraryPage( void )
 
 	wxBoxSizer * LibOptPathBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_LibOptAddPathBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LibOptAddPathBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LibOptAddPathBtn->Enable( false );
 	LibOptPathBtnSizer->Add( m_LibOptAddPathBtn, 0, wxTOP, 5 );
 
-	m_LibOptDelPathBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LibOptDelPathBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LibOptDelPathBtn->Enable( false );
 	LibOptPathBtnSizer->Add( m_LibOptDelPathBtn, 0, wxBOTTOM, 5 );
 
@@ -812,19 +812,19 @@ void guPrefDialog::BuildLibraryPage( void )
 
 	wxBoxSizer * LibOptCoverBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_LibOptAddCoverBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LibOptAddCoverBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_LibOptAddCoverBtn->Enable( false );
 	LibOptCoverBtnSizer->Add( m_LibOptAddCoverBtn, 0, wxTOP, 5 );
 
-	m_LibOptUpCoverBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guImage( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LibOptUpCoverBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LibOptUpCoverBtn->Enable( false );
 	LibOptCoverBtnSizer->Add( m_LibOptUpCoverBtn, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_LibOptDownCoverBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guImage( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LibOptDownCoverBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LibOptDownCoverBtn->Enable( false );
 	LibOptCoverBtnSizer->Add( m_LibOptDownCoverBtn, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_LibOptDelCoverBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LibOptDelCoverBtn = new wxBitmapButton( m_LibOptPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LibOptDelCoverBtn->Enable( false );
 	LibOptCoverBtnSizer->Add( m_LibOptDelCoverBtn, 0, wxBOTTOM, 5 );
 
@@ -1487,19 +1487,19 @@ void guPrefDialog::BuildLyricsPage( void )
 
 	wxBoxSizer * LyricsSrcBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_LyricsAddButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LyricsAddButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	//m_LyricsAddButton->Enable( false );
 	LyricsSrcBtnSizer->Add( m_LyricsAddButton, 0, wxTOP, 5 );
 
-	m_LyricsUpButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guImage( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LyricsUpButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LyricsUpButton->Enable( false );
 	LyricsSrcBtnSizer->Add( m_LyricsUpButton, 0, wxALIGN_CENTER_HORIZONTAL|wxTOP, 5 );
 
-	m_LyricsDownButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guImage( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LyricsDownButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LyricsDownButton->Enable( false );
 	LyricsSrcBtnSizer->Add( m_LyricsDownButton, 0, wxALIGN_CENTER_HORIZONTAL|wxTOP, 5 );
 
-	m_LyricsDelButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LyricsDelButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LyricsDelButton->Enable( false );
 	LyricsSrcBtnSizer->Add( m_LyricsDelButton, 0, wxTOP|wxBOTTOM, 5 );
 
@@ -1527,19 +1527,19 @@ void guPrefDialog::BuildLyricsPage( void )
 
 	wxBoxSizer * LyricsSaveBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_LyricsSaveAddButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LyricsSaveAddButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	//m_LyricsSaveAddButton->Enable( false );
 	LyricsSaveBtnSizer->Add( m_LyricsSaveAddButton, 0, wxTOP|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_LyricsSaveUpButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guImage( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LyricsSaveUpButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LyricsSaveUpButton->Enable( false );
 	LyricsSaveBtnSizer->Add( m_LyricsSaveUpButton, 0, wxALIGN_CENTER_HORIZONTAL|wxTOP, 5 );
 
-	m_LyricsSaveDownButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guImage( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LyricsSaveDownButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LyricsSaveDownButton->Enable( false );
 	LyricsSaveBtnSizer->Add( m_LyricsSaveDownButton, 0, wxALIGN_CENTER_HORIZONTAL|wxTOP, 5 );
 
-	m_LyricsSaveDelButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_LyricsSaveDelButton = new wxBitmapButton( m_LyricsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_LyricsSaveDelButton->Enable( false );
 	LyricsSaveBtnSizer->Add( m_LyricsSaveDelButton, 0, wxTOP|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL, 5 );
 
@@ -1617,10 +1617,10 @@ void guPrefDialog::BuildOnlinePage( void )
 
     wxBoxSizer * OnlineBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-    m_OnlineAddBtn = new wxBitmapButton( m_OnlinePanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, 0 );
+    m_OnlineAddBtn = new wxBitmapButton( m_OnlinePanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, 0 );
     OnlineBtnSizer->Add( m_OnlineAddBtn, 0, wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-    m_OnlineDelBtn = new wxBitmapButton( m_OnlinePanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_OnlineDelBtn = new wxBitmapButton( m_OnlinePanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_OnlineDelBtn->Disable();
     OnlineBtnSizer->Add( m_OnlineDelBtn, 0, wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
@@ -2034,21 +2034,25 @@ void guPrefDialog::BuildLinksPage( void )
     //
     // Links
     //
-	wxBoxSizer * LinksMainSizer = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer * LinksMainSizer = new wxBoxSizer( wxVERTICAL );
 
-	wxStaticBoxSizer * LinksLabelSizer = new wxStaticBoxSizer( new wxStaticBox( m_LinksPanel, wxID_ANY, _(" Links ") ), wxVERTICAL );
+    wxStaticBoxSizer * LinksLabelSizer = new wxStaticBoxSizer( new wxStaticBox( m_LinksPanel, wxID_ANY, _(" Links ") ), wxVERTICAL );
 
-	wxBoxSizer * LinksListBoxSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer * LinksListBoxSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	m_LinksListBox = new wxListBox( m_LinksPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 );
+    m_LinksListBox = new wxListBox( m_LinksPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 );
     wxArrayString SearchLinks = m_Config->ReadAStr( wxT( "Link" ), wxEmptyString, wxT( "searchlinks/links" ) );
-	m_LinksListBox->Append( SearchLinks );
-	m_LinksNames = m_Config->ReadAStr( wxT( "Name" ), wxEmptyString, wxT( "searchlinks/names" ) );
+    m_LinksListBox->Append( SearchLinks );
+    m_LinksNames = m_Config->ReadAStr( wxT( "Name" ), wxEmptyString, wxT( "searchlinks/names" ) );
     int count = m_LinksListBox->GetCount();
-	while( ( int ) m_LinksNames.Count() < count )
+    while( ( int ) m_LinksNames.Count() < count )
+    {
         m_LinksNames.Add( wxEmptyString );
-	while( ( int ) m_LinksNames.Count() > count )
+    }
+    while( ( int ) m_LinksNames.Count() > count )
+    {
         m_LinksNames.RemoveAt( count );
+    }
 
     int index;
     for( index = 0; index < count; index++ )
@@ -2060,89 +2064,89 @@ void guPrefDialog::BuildLinksPage( void )
         }
     }
 
-	LinksListBoxSizer->Add( m_LinksListBox, 1, wxALL|wxEXPAND, 5 );
+    LinksListBoxSizer->Add( m_LinksListBox, 1, wxALL|wxEXPAND, 5 );
 
-	wxBoxSizer * LinksBtnSizer = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer * LinksBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_LinksAddBtn = new wxBitmapButton( m_LinksPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, 0 );
+    m_LinksAddBtn = new wxBitmapButton( m_LinksPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, 0 );
     m_LinksAddBtn->Enable( false );
-	LinksBtnSizer->Add( m_LinksAddBtn, 0, wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
+    LinksBtnSizer->Add( m_LinksAddBtn, 0, wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_LinksMoveUpBtn = new wxBitmapButton( m_LinksPanel, wxID_ANY, guImage( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_LinksMoveUpBtn->Enable( false );
-	LinksBtnSizer->Add( m_LinksMoveUpBtn, 0, wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
+    m_LinksMoveUpBtn = new wxBitmapButton( m_LinksPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_LinksMoveUpBtn->Enable( false );
+    LinksBtnSizer->Add( m_LinksMoveUpBtn, 0, wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_LinksMoveDownBtn = new wxBitmapButton( m_LinksPanel, wxID_ANY, guImage( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_LinksMoveDownBtn->Enable( false );
-	LinksBtnSizer->Add( m_LinksMoveDownBtn, 0, wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
+    m_LinksMoveDownBtn = new wxBitmapButton( m_LinksPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_LinksMoveDownBtn->Enable( false );
+    LinksBtnSizer->Add( m_LinksMoveDownBtn, 0, wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_LinksDelBtn = new wxBitmapButton( m_LinksPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_LinksDelBtn->Enable( false );
-	LinksBtnSizer->Add( m_LinksDelBtn, 0, wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
+    m_LinksDelBtn = new wxBitmapButton( m_LinksPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_LinksDelBtn->Enable( false );
+    LinksBtnSizer->Add( m_LinksDelBtn, 0, wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	LinksListBoxSizer->Add( LinksBtnSizer, 0, wxEXPAND, 5 );
+    LinksListBoxSizer->Add( LinksBtnSizer, 0, wxEXPAND, 5 );
 
-	LinksLabelSizer->Add( LinksListBoxSizer, 1, wxEXPAND, 5 );
+    LinksLabelSizer->Add( LinksListBoxSizer, 1, wxEXPAND, 5 );
 
-	wxBoxSizer * LinksEditorSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer * LinksEditorSizer = new wxBoxSizer( wxHORIZONTAL );
 
     wxFlexGridSizer * LinksFieldsSizer = new wxFlexGridSizer( 2, 0, 0 );
-	LinksFieldsSizer->AddGrowableCol( 1 );
-	LinksFieldsSizer->SetFlexibleDirection( wxBOTH );
-	LinksFieldsSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    LinksFieldsSizer->AddGrowableCol( 1 );
+    LinksFieldsSizer->SetFlexibleDirection( wxBOTH );
+    LinksFieldsSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
-	wxStaticText * LinkUrlStaticText = new wxStaticText( m_LinksPanel, wxID_ANY, _("URL:"), wxDefaultPosition, wxDefaultSize, 0 );
-	LinkUrlStaticText->Wrap( -1 );
-	LinksFieldsSizer->Add( LinkUrlStaticText, 0, wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
+    wxStaticText * LinkUrlStaticText = new wxStaticText( m_LinksPanel, wxID_ANY, _("URL:"), wxDefaultPosition, wxDefaultSize, 0 );
+    LinkUrlStaticText->Wrap( -1 );
+    LinksFieldsSizer->Add( LinkUrlStaticText, 0, wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
 
-	m_LinksUrlTextCtrl = new wxTextCtrl( m_LinksPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	LinksFieldsSizer->Add( m_LinksUrlTextCtrl, 1, wxALL|wxALIGN_CENTER_VERTICAL|wxEXPAND, 5 );
+    m_LinksUrlTextCtrl = new wxTextCtrl( m_LinksPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    LinksFieldsSizer->Add( m_LinksUrlTextCtrl, 1, wxALL|wxALIGN_CENTER_VERTICAL|wxEXPAND, 5 );
 
-	wxStaticText * LinkNameStaticText = new wxStaticText( m_LinksPanel, wxID_ANY, _("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
-	LinkNameStaticText->Wrap( -1 );
-	LinksFieldsSizer->Add( LinkNameStaticText, 0, wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
+    wxStaticText * LinkNameStaticText = new wxStaticText( m_LinksPanel, wxID_ANY, _("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
+    LinkNameStaticText->Wrap( -1 );
+    LinksFieldsSizer->Add( LinkNameStaticText, 0, wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
 
-	m_LinksNameTextCtrl = new wxTextCtrl( m_LinksPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	LinksFieldsSizer->Add( m_LinksNameTextCtrl, 1, wxALL|wxALIGN_CENTER_VERTICAL|wxEXPAND, 5 );
+    m_LinksNameTextCtrl = new wxTextCtrl( m_LinksPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    LinksFieldsSizer->Add( m_LinksNameTextCtrl, 1, wxALL|wxALIGN_CENTER_VERTICAL|wxEXPAND, 5 );
 
-	LinksEditorSizer->Add( LinksFieldsSizer, 1, wxEXPAND, 5 );
+    LinksEditorSizer->Add( LinksFieldsSizer, 1, wxEXPAND, 5 );
 
-	m_LinksAcceptBtn = new wxBitmapButton( m_LinksPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_LinksAcceptBtn->Enable( false );
+    m_LinksAcceptBtn = new wxBitmapButton( m_LinksPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_LinksAcceptBtn->Enable( false );
 
-	LinksEditorSizer->Add( m_LinksAcceptBtn, 0, wxALL, 5 );
+    LinksEditorSizer->Add( m_LinksAcceptBtn, 0, wxALL, 5 );
 
-	LinksLabelSizer->Add( LinksEditorSizer, 0, wxEXPAND, 5 );
+    LinksLabelSizer->Add( LinksEditorSizer, 0, wxEXPAND, 5 );
 
-	LinksMainSizer->Add( LinksLabelSizer, 1, wxEXPAND|wxALL, 5 );
+    LinksMainSizer->Add( LinksLabelSizer, 1, wxEXPAND|wxALL, 5 );
 
-	wxStaticBoxSizer * LinksHelpSizer = new wxStaticBoxSizer( new wxStaticBox( m_LinksPanel, wxID_ANY, _(" Define URLs using ") ), wxHORIZONTAL );
+    wxStaticBoxSizer * LinksHelpSizer = new wxStaticBoxSizer( new wxStaticBox( m_LinksPanel, wxID_ANY, _(" Define URLs using ") ), wxHORIZONTAL );
 
-	wxStaticText * LinksHelpText = new wxStaticText( m_LinksPanel, wxID_ANY, wxT("{lang}:\n{text}:"), wxDefaultPosition, wxDefaultSize, 0 );
-	LinksHelpText->Wrap( -1 );
-	LinksHelpSizer->Add( LinksHelpText, 0, wxALL, 5 );
+    wxStaticText * LinksHelpText = new wxStaticText( m_LinksPanel, wxID_ANY, wxT("{lang}:\n{text}:"), wxDefaultPosition, wxDefaultSize, 0 );
+    LinksHelpText->Wrap( -1 );
+    LinksHelpSizer->Add( LinksHelpText, 0, wxALL, 5 );
 
-	LinksHelpText = new wxStaticText( m_LinksPanel, wxID_ANY, _( "2 letters language code\nText to search"), wxDefaultPosition, wxDefaultSize, 0 );
-	LinksHelpText->Wrap( -1 );
-	LinksHelpSizer->Add( LinksHelpText, 0, wxALL, 5 );
+    LinksHelpText = new wxStaticText( m_LinksPanel, wxID_ANY, _( "2 letters language code\nText to search"), wxDefaultPosition, wxDefaultSize, 0 );
+    LinksHelpText->Wrap( -1 );
+    LinksHelpSizer->Add( LinksHelpText, 0, wxALL, 5 );
 
-	LinksMainSizer->Add( LinksHelpSizer, 0, wxEXPAND|wxALL, 5 );
+    LinksMainSizer->Add( LinksHelpSizer, 0, wxEXPAND|wxALL, 5 );
 
-	m_LinksPanel->SetSizer( LinksMainSizer );
-	m_LinksPanel->Layout();
-	LinksMainSizer->FitInside( m_LinksPanel );
+    m_LinksPanel->SetSizer( LinksMainSizer );
+    m_LinksPanel->Layout();
+    LinksMainSizer->FitInside( m_LinksPanel );
 
     //
     //
     //
-	m_LinksListBox->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( guPrefDialog::OnLinksListBoxSelected ), NULL, this );
-	m_LinksAddBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guPrefDialog::OnLinksAddBtnClick ), NULL, this );
-	m_LinksDelBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guPrefDialog::OnLinksDelBtnClick ), NULL, this );
-	m_LinksMoveUpBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guPrefDialog::OnLinkMoveUpBtnClick ), NULL, this );
-	m_LinksMoveDownBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guPrefDialog::OnLinkMoveDownBtnClick ), NULL, this );
-	m_LinksUrlTextCtrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guPrefDialog::OnLinksTextChanged ), NULL, this );
-	m_LinksNameTextCtrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guPrefDialog::OnLinksTextChanged ), NULL, this );
-	m_LinksAcceptBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guPrefDialog::OnLinksSaveBtnClick ), NULL, this );
+    m_LinksListBox->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( guPrefDialog::OnLinksListBoxSelected ), NULL, this );
+    m_LinksAddBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guPrefDialog::OnLinksAddBtnClick ), NULL, this );
+    m_LinksDelBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guPrefDialog::OnLinksDelBtnClick ), NULL, this );
+    m_LinksMoveUpBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guPrefDialog::OnLinkMoveUpBtnClick ), NULL, this );
+    m_LinksMoveDownBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guPrefDialog::OnLinkMoveDownBtnClick ), NULL, this );
+    m_LinksUrlTextCtrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guPrefDialog::OnLinksTextChanged ), NULL, this );
+    m_LinksNameTextCtrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guPrefDialog::OnLinksTextChanged ), NULL, this );
+    m_LinksAcceptBtn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guPrefDialog::OnLinksSaveBtnClick ), NULL, this );
 
 }
 
@@ -2185,19 +2189,19 @@ void guPrefDialog::BuildCommandsPage( void )
 
 	wxBoxSizer * CmdBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_CmdAddBtn = new wxBitmapButton( m_CmdPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_CmdAddBtn = new wxBitmapButton( m_CmdPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, 0 );
 	m_CmdAddBtn->Enable( false );
 	CmdBtnSizer->Add( m_CmdAddBtn, 0, wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_CmdMoveUpBtn = new wxBitmapButton( m_CmdPanel, wxID_ANY, guImage( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_CmdMoveUpBtn = new wxBitmapButton( m_CmdPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_CmdMoveUpBtn->Enable( false );
 	CmdBtnSizer->Add( m_CmdMoveUpBtn, 0, wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_CmdMoveDownBtn = new wxBitmapButton( m_CmdPanel, wxID_ANY, guImage( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_CmdMoveDownBtn = new wxBitmapButton( m_CmdPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_CmdMoveDownBtn->Enable( false );
 	CmdBtnSizer->Add( m_CmdMoveDownBtn, 0, wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_CmdDelBtn = new wxBitmapButton( m_CmdPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_CmdDelBtn = new wxBitmapButton( m_CmdPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_CmdDelBtn->Enable( false );
 	CmdBtnSizer->Add( m_CmdDelBtn, 0, wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
@@ -2228,7 +2232,7 @@ void guPrefDialog::BuildCommandsPage( void )
 
 	CmdEditorSizer->Add( CmdFieldsSizer, 1, wxEXPAND, 5 );
 
-	m_CmdAcceptBtn = new wxBitmapButton( m_CmdPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_CmdAcceptBtn = new wxBitmapButton( m_CmdPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_CmdAcceptBtn->Enable( false );
 
 	CmdEditorSizer->Add( m_CmdAcceptBtn, 0, wxALL, 5 );
@@ -2311,23 +2315,23 @@ void guPrefDialog::BuildCopyToPage( void )
 
 	wxBoxSizer * CopyToBtnSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_CopyToAddBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_CopyToAddBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, 0 );
 	m_CopyToAddBtn->Enable( false );
 	CopyToBtnSizer->Add( m_CopyToAddBtn, 0, wxTOP|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_CopyToUpBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guImage( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_CopyToUpBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, 0 );
 	m_CopyToUpBtn->Enable( false );
 	CopyToBtnSizer->Add( m_CopyToUpBtn, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_CopyToDownBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guImage( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, 0 );
+	m_CopyToDownBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, 0 );
 	m_CopyToDownBtn->Enable( false );
 	CopyToBtnSizer->Add( m_CopyToDownBtn, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_CopyToDelBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_CopyToDelBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_CopyToDelBtn->Enable( false );
 	CopyToBtnSizer->Add( m_CopyToDelBtn, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	m_CopyToAcceptBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_CopyToAcceptBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_CopyToAcceptBtn->Enable( false );
 	CopyToBtnSizer->Add( m_CopyToAcceptBtn, 0, wxBOTTOM|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
@@ -2399,7 +2403,7 @@ void guPrefDialog::BuildCopyToPage( void )
 
 	CopyToEditorSizer->Add( CopyToOptionsSizer, 1, wxEXPAND, 5 );
 
-//	m_CopyToAcceptBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+//	m_CopyToAcceptBtn = new wxBitmapButton( m_CopyPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_accept ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 //	m_CopyToAcceptBtn->Enable( false );
 //
 //	CopyToEditorSizer->Add( m_CopyToAcceptBtn, 0, wxALL|wxALIGN_BOTTOM, 5 );

--- a/src/RaListBox.cpp
+++ b/src/RaListBox.cpp
@@ -36,8 +36,8 @@ guRaListBox::guRaListBox( wxWindow * parent, guLibPanel * libpanel, guDbLibrary 
 {
     m_LibPanel = libpanel;
 
-    m_NormalStar   = new wxBitmap( guImage( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_normal_tiny + GURATING_STYLE_MID ) ) );
-    m_SelectStar = new wxBitmap( guImage( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_highlight_tiny + GURATING_STYLE_MID ) ) );
+    m_NormalStar = guNS_Image::GetBitmap( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_normal_tiny + GURATING_STYLE_MID ) );
+    m_SelectStar = guNS_Image::GetBitmap( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_highlight_tiny + GURATING_STYLE_MID ) );
 
     CreateAcceleratorTable();
 
@@ -46,12 +46,7 @@ guRaListBox::guRaListBox( wxWindow * parent, guLibPanel * libpanel, guDbLibrary 
 
 // -------------------------------------------------------------------------------- //
 guRaListBox::~guRaListBox()
-{
-    if( m_NormalStar )
-        delete m_NormalStar;
-    if( m_SelectStar )
-        delete m_SelectStar;
-}
+{}
 
 // -------------------------------------------------------------------------------- //
 void guRaListBox::CreateAcceleratorTable( void )
@@ -124,7 +119,7 @@ void guRaListBox::DrawItem( wxDC &dc, const wxRect &rect, const int row, const i
 
         for( x = 0; x < 5; x++ )
         {
-           dc.DrawBitmap( ( x >= Rating ) ? * m_NormalStar : * m_SelectStar,
+           dc.DrawBitmap( ( x >= Rating ) ? m_NormalStar : m_SelectStar,
                           rect.x + 3 + ( w * x ), rect.y + 3, true );
         }
     }
@@ -141,14 +136,14 @@ void guRaListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_RATING_PLAY,
                             wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play the selected tracks" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( Menu, ID_RATING_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add current selected tracks to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -157,21 +152,21 @@ void guRaListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( EnqueueMenu, ID_RATING_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_RATING_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_RATING_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -186,7 +181,7 @@ void guRaListBox::CreateContextMenu( wxMenu * Menu ) const
             MenuItem = new wxMenuItem( Menu, ID_RATING_EDITTRACKS,
                                 wxString( _( "Edit Songs" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                                 _( "Edit the selected tracks" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu->Append( MenuItem );
         }
 
@@ -195,7 +190,7 @@ void guRaListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_RATING_SAVETOPLAYLIST,
                                 wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                                 _( "Save the selected tracks to playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         if( ContextMenuFlags & guCONTEXTMENU_COPY_TO )

--- a/src/RaListBox.h
+++ b/src/RaListBox.h
@@ -32,8 +32,8 @@ class guRaListBox : public guAccelListBox
   protected :
     guLibPanel *    m_LibPanel;
 
-    wxBitmap *      m_NormalStar;
-    wxBitmap *      m_SelectStar;
+    wxBitmap        m_NormalStar;
+    wxBitmap        m_SelectStar;
 
     virtual void    GetItemsList( void );
     virtual void    CreateContextMenu( wxMenu * menu ) const;

--- a/src/RadioPanel.cpp
+++ b/src/RadioPanel.cpp
@@ -421,13 +421,13 @@ void guRadioStationListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_RADIO_PLAY,
                             wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play current selected songs" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_RADIO_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add current selected songs to playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         Menu->Append( MenuItem );
 
         wxMenu * EnqueueMenu = new wxMenu();
@@ -435,21 +435,21 @@ void guRadioStationListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( EnqueueMenu, ID_RADIO_ENQUEUE_AFTER_TRACK,
                                 wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                                 _( "Add current selected tracks to playlist after the current track" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
         MenuItem->Enable( SelCount );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_RADIO_ENQUEUE_AFTER_ALBUM,
                                 wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                                 _( "Add current selected tracks to playlist after the current album" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
         MenuItem->Enable( SelCount );
 
         MenuItem = new wxMenuItem( EnqueueMenu, ID_RADIO_ENQUEUE_AFTER_ARTIST,
                                 wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                                 _( "Add current selected tracks to playlist after the current artist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         EnqueueMenu->Append( MenuItem );
         MenuItem->Enable( SelCount );
 

--- a/src/RatingCtrl.cpp
+++ b/src/RatingCtrl.cpp
@@ -39,8 +39,8 @@ guRating::guRating( wxWindow * parent, const int style ) :
     m_Rating = wxNOT_FOUND;
     m_Style = style;
 
-    m_NormalStar   = new wxBitmap( guImage( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_normal_tiny + style ) ) );
-    m_SelectStar = new wxBitmap( guImage( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_highlight_tiny + style ) ) );
+    m_NormalStar   = new wxBitmap( guNS_Image::GetBitmap( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_normal_tiny + style ) ) );
+    m_SelectStar = new wxBitmap( guNS_Image::GetBitmap( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_highlight_tiny + style ) ) );
 }
 
 // -------------------------------------------------------------------------------- //

--- a/src/ShoutcastRadio.cpp
+++ b/src/ShoutcastRadio.cpp
@@ -67,17 +67,17 @@ bool guShoutcastRadioProvider::OnContextMenu( wxMenu * menu, const wxTreeItemId 
             menu->AppendSeparator();
         }
         MenuItem = new wxMenuItem( menu, ID_RADIO_GENRE_ADD, _( "Add Genre" ), _( "Create a new genre" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         menu->Append( MenuItem );
 
         if( ItemData )
         {
             MenuItem = new wxMenuItem( menu, ID_RADIO_GENRE_EDIT, _( "Edit genre" ), _( "Change the selected genre" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             menu->Append( MenuItem );
 
             MenuItem = new wxMenuItem( menu, ID_RADIO_GENRE_DELETE, _( "Delete genre" ), _( "Delete the selected search" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
             menu->Append( MenuItem );
         }
         if( !selcount )
@@ -92,17 +92,17 @@ bool guShoutcastRadioProvider::OnContextMenu( wxMenu * menu, const wxTreeItemId 
             menu->AppendSeparator();
         }
         MenuItem = new wxMenuItem( menu, ID_RADIO_SEARCH_ADD, _( "Add Search" ), _( "Create a new search" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
         menu->Append( MenuItem );
 
         if( ItemData )
         {
             MenuItem = new wxMenuItem( menu, ID_RADIO_SEARCH_EDIT, _( "Edit search" ), _( "Change the selected search" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             menu->Append( MenuItem );
 
             MenuItem = new wxMenuItem( menu, ID_RADIO_SEARCH_DELETE, _( "Delete search" ), _( "Delete the selected search" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
             menu->Append( MenuItem );
         }
         if( !selcount )
@@ -117,7 +117,7 @@ bool guShoutcastRadioProvider::OnContextMenu( wxMenu * menu, const wxTreeItemId 
     }
 
     MenuItem = new wxMenuItem( menu, ID_RADIO_DOUPDATE, _( "Update Radio Stations" ), _( "Update the radio station lists" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_reload ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_reload ) );
     menu->Append( MenuItem );
 
     return true;
@@ -126,9 +126,9 @@ bool guShoutcastRadioProvider::OnContextMenu( wxMenu * menu, const wxTreeItemId 
 // -------------------------------------------------------------------------------- //
 void guShoutcastRadioProvider::RegisterImages( wxImageList * imagelist )
 {
-    imagelist->Add( guImage( guIMAGE_INDEX_tiny_shoutcast ) );
+    imagelist->Add( guNS_Image::GetImage( guIMAGE_INDEX_tiny_shoutcast ) );
     m_ImageIds.Add( imagelist->GetImageCount() - 1 );
-    imagelist->Add( guImage( guIMAGE_INDEX_search ) );
+    imagelist->Add( guNS_Image::GetImage( guIMAGE_INDEX_search ) );
     m_ImageIds.Add( imagelist->GetImageCount() - 1 );
 }
 

--- a/src/SoListBox.cpp
+++ b/src/SoListBox.cpp
@@ -77,8 +77,8 @@ guSoListBox::guSoListBox( wxWindow * parent, guMediaViewer * mediaviewer, wxStri
         InsertColumn( Column );
     }
 
-    m_NormalStar   = new wxBitmap( guImage( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_normal_tiny + GURATING_STYLE_MID ) ) );
-    m_SelectStar = new wxBitmap( guImage( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_highlight_tiny + GURATING_STYLE_MID ) ) );
+    m_NormalStar   = new wxBitmap( guNS_Image::GetBitmap( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_normal_tiny + GURATING_STYLE_MID ) ) );
+    m_SelectStar = new wxBitmap( guNS_Image::GetBitmap( ( guIMAGE_INDEX ) ( guIMAGE_INDEX_star_highlight_tiny + GURATING_STYLE_MID ) ) );
 
     Connect( ID_LINKS_BASE, ID_LINKS_BASE + guLINKS_MAXCOUNT, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( guSoListBox::OnSearchLinkClicked ), NULL, this );
     Connect( ID_COMMANDS_BASE, ID_COMMANDS_BASE + guCOMMANDS_MAXCOUNT, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( guSoListBox::OnCommandClicked ), NULL, this );
@@ -494,7 +494,7 @@ void guSoListBox::AppendFastEditMenu( wxMenu * menu, const int selcount ) const
     MenuText += wxT( " " ) + ColumnNames[ ColumnId ];
 
     MenuItem = new wxMenuItem( menu, ID_TRACKS_EDIT_COLUMN,  MenuText, _( "Edit the clicked column for the selected tracks" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
     menu->Append( MenuItem );
 
     if( selcount > 1 )
@@ -507,7 +507,7 @@ void guSoListBox::AppendFastEditMenu( wxMenu * menu, const int selcount ) const
         MenuText += wxT( " '" ) + ItemText + wxT( "'" );
 
         MenuItem = new wxMenuItem( menu, ID_TRACKS_SET_COLUMN,  MenuText, _( "Set the clicked column for the selected tracks" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
         menu->Append( MenuItem );
     }
 }
@@ -523,14 +523,14 @@ void guSoListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_TRACKS_PLAY,
                             wxString( _( "Play" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play current selected songs" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( Menu, ID_TRACKS_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add current selected songs to the playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -539,21 +539,21 @@ void guSoListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( EnqueueMenu, ID_TRACKS_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_TRACKS_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_TRACKS_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -566,7 +566,7 @@ void guSoListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_TRACKS_EDITLABELS,
                                 wxString( _( "Edit Labels" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITLABELS ),
                                 _( "Edit the labels assigned to the selected songs" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tags ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tags ) );
         Menu->Append( MenuItem );
 
         if( ContextMenuFlags & guCONTEXTMENU_EDIT_TRACKS )
@@ -574,7 +574,7 @@ void guSoListBox::CreateContextMenu( wxMenu * Menu ) const
             MenuItem = new wxMenuItem( Menu, ID_TRACKS_EDITTRACKS,
                                 wxString( _( "Edit Songs" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                                 _( "Edit the songs selected" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu->Append( MenuItem );
 
             Menu->AppendSeparator();
@@ -621,7 +621,7 @@ void guSoListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_TRACKS_SAVETOPLAYLIST,
                                 wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                                 _( "Save all selected tracks as a playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         if( SelCount == 1 )
@@ -635,12 +635,12 @@ void guSoListBox::CreateContextMenu( wxMenu * Menu ) const
         if( ContextMenuFlags & guCONTEXTMENU_DELETEFROMLIBRARY )
         {
             MenuItem = new wxMenuItem( Menu, ID_TRACKS_DELETE_LIBRARY, _( "Remove from Library" ), _( "Remove the current selected tracks from library" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
             Menu->Append( MenuItem );
         }
 
         MenuItem = new wxMenuItem( Menu, ID_TRACKS_DELETE_DRIVE, _( "Delete from Drive" ), _( "Remove the current selected tracks from drive" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
         Menu->Append( MenuItem );
 
         Menu->AppendSeparator();

--- a/src/SplashWin.cpp
+++ b/src/SplashWin.cpp
@@ -30,39 +30,40 @@ guSplashFrame::guSplashFrame( wxWindow * parent, int timeout ) :
 {
     CentreOnScreen();
 
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 
-    m_Bitmap = new wxBitmap( guImage( guIMAGE_INDEX_splash ) );
+    m_Bitmap = new wxBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_splash ) );
 
-	wxBoxSizer* MainSizer;
-	MainSizer = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer* MainSizer;
+    MainSizer = new wxBoxSizer( wxVERTICAL );
 
-	MainSizer->Add( 0, 0, 1, wxEXPAND, 5 );
+    MainSizer->Add( 0, 0, 1, wxEXPAND, 5 );
 
-	wxColour FontColor = wxColour( 120, 120, 120 );
+    wxColour FontColor = wxColour( 120, 120, 120 );
     wxString Version = wxT( ID_GUAYADEQUE_VERSION );
 #ifdef ID_GUAYADEQUE_REVISION
     Version += wxT( "-" ID_GUAYADEQUE_REVISION );
 #endif
-	m_Version = new wxStaticText( this, wxID_ANY, Version, wxDefaultPosition, wxDefaultSize, 0 );
-	m_Version->Wrap( -1 );
-	m_Version->SetForegroundColour( FontColor );
-	m_Version->SetBackgroundColour( * wxWHITE );
-	MainSizer->Add( m_Version, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
+
+    m_Version = new wxStaticText( this, wxID_ANY, Version, wxDefaultPosition, wxDefaultSize, 0 );
+    m_Version->Wrap( -1 );
+    m_Version->SetForegroundColour( FontColor );
+    m_Version->SetBackgroundColour( * wxWHITE );
+    MainSizer->Add( m_Version, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
     m_Email = new wxHyperlinkCtrl( this, wxID_ANY, wxT( "J.Rios anonbeat@gmail.com" ), wxT( "mailto:anonbeat@gmail.com" ), wxDefaultPosition, wxDefaultSize, wxHL_ALIGN_RIGHT );
-	m_Email->SetHoverColour( FontColor );
-	m_Email->SetNormalColour( FontColor );
-	m_Email->SetVisitedColour( FontColor );
-	m_Email->SetBackgroundColour( * wxWHITE );
+    m_Email->SetHoverColour( FontColor );
+    m_Email->SetNormalColour( FontColor );
+    m_Email->SetVisitedColour( FontColor );
+    m_Email->SetBackgroundColour( * wxWHITE );
     m_Email->SetCanFocus( false );
     MainSizer->Add( m_Email, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
     m_HomePage = new wxHyperlinkCtrl( this, wxID_ANY, wxT( "guayadeque.org" ), wxT( "http://guayadeque.org" ), wxDefaultPosition, wxDefaultSize, wxHL_ALIGN_RIGHT );
-	m_HomePage->SetHoverColour( FontColor );
-	m_HomePage->SetNormalColour( FontColor );
-	m_HomePage->SetVisitedColour( FontColor );
-	m_HomePage->SetBackgroundColour( * wxWHITE );
+    m_HomePage->SetHoverColour( FontColor );
+    m_HomePage->SetNormalColour( FontColor );
+    m_HomePage->SetVisitedColour( FontColor );
+    m_HomePage->SetBackgroundColour( * wxWHITE );
     m_HomePage->SetCanFocus( false );
     MainSizer->Add( m_HomePage, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
@@ -74,8 +75,8 @@ guSplashFrame::guSplashFrame( wxWindow * parent, int timeout ) :
 //	m_Donate->SetBackgroundColour( * wxWHITE );
 //	MainSizer->Add( m_Donate, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
-	this->SetSizer( MainSizer );
-	this->Layout();
+    this->SetSizer( MainSizer );
+    this->Layout();
 
     Show( true );
     SetThemeEnabled( false );
@@ -87,8 +88,8 @@ guSplashFrame::guSplashFrame( wxWindow * parent, int timeout ) :
 	// Connect Events
 //    Connect( wxEVT_PAINT, wxPaintEventHandler( guSplashFrame::OnPaint ), NULL, this );
     Connect( wxEVT_ERASE_BACKGROUND,  wxEraseEventHandler( guSplashFrame::OnEraseBackground ), NULL, this );
-	Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler( guSplashFrame::OnSplashClick ), NULL, this );
-	Connect( wxEVT_TIMER, wxTimerEventHandler( guSplashFrame::OnTimeout ), NULL, this );
+    Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler( guSplashFrame::OnSplashClick ), NULL, this );
+    Connect( wxEVT_TIMER, wxTimerEventHandler( guSplashFrame::OnTimeout ), NULL, this );
 }
 
 // -------------------------------------------------------------------------------- //
@@ -102,8 +103,8 @@ guSplashFrame::~guSplashFrame()
 	// Disconnect Events
 //    Disconnect( wxEVT_PAINT, wxPaintEventHandler( guSplashFrame::OnPaint ), NULL, this );
     Disconnect( wxEVT_ERASE_BACKGROUND,  wxEraseEventHandler( guSplashFrame::OnEraseBackground ), NULL, this );
-	Disconnect( wxEVT_LEFT_DOWN, wxMouseEventHandler( guSplashFrame::OnSplashClick ), NULL, this );
-	Disconnect( wxEVT_TIMER, wxTimerEventHandler( guSplashFrame::OnTimeout ), NULL, this );
+    Disconnect( wxEVT_LEFT_DOWN, wxMouseEventHandler( guSplashFrame::OnSplashClick ), NULL, this );
+    Disconnect( wxEVT_TIMER, wxTimerEventHandler( guSplashFrame::OnTimeout ), NULL, this );
 }
 
 // -------------------------------------------------------------------------------- //

--- a/src/StatusBar.cpp
+++ b/src/StatusBar.cpp
@@ -163,10 +163,10 @@ guStatusBar::guStatusBar( wxWindow * parent ) :
     int FadeOutTime = Config->ReadNum( wxT( "FadeOutTime" ), 50, wxT( "crossfader" ) ) * 100;
     m_ForceGapless = ( !FadeOutTime || Config->ReadBool( wxT( "ForceGapless" ), false, wxT( "crossfader" ) ) );
 
-    m_ASBitmap = new wxStaticBitmap( this, wxID_ANY, guImage( guIMAGE_INDEX_lastfm_as_off ) );
+    m_ASBitmap = new wxStaticBitmap( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_lastfm_as_off ) );
     m_ASBitmap->SetToolTip( _( "Enable audioscrobbling" ) );
 
-    m_PlayMode = new wxStaticBitmap( this, wxID_ANY, guImage( m_ForceGapless ? guIMAGE_INDEX_tiny_gapless : guIMAGE_INDEX_tiny_crossfade ) );
+    m_PlayMode = new wxStaticBitmap( this, wxID_ANY, guNS_Image::GetBitmap( m_ForceGapless ? guIMAGE_INDEX_tiny_gapless : guIMAGE_INDEX_tiny_crossfade ) );
     m_PlayMode->SetToolTip( m_ForceGapless ? _( "Enable crossfading" ) : _( "Disable crossfading" ) );
 
     m_SelInfo = new wxStaticText( this, wxID_ANY, wxEmptyString );
@@ -265,7 +265,7 @@ void guStatusBar::UpdateAudioScrobbleIcon( bool Enabled )
 {
     if( m_ASBitmap )
     {
-        m_ASBitmap->SetBitmap( guImage( Enabled ? guIMAGE_INDEX_lastfm_as_on : guIMAGE_INDEX_lastfm_as_off ) );
+        m_ASBitmap->SetBitmap( guNS_Image::GetBitmap( Enabled ? guIMAGE_INDEX_lastfm_as_on : guIMAGE_INDEX_lastfm_as_off ) );
         m_ASBitmap->SetToolTip( Enabled ? _( "Disable audioscrobbling" ) : _( "Enable audioscrobbling" ) );
         m_ASBitmap->Refresh();
     }
@@ -282,7 +282,7 @@ void guStatusBar::SetPlayMode( const bool forcegapless )
         Config->Flush();
         if( m_PlayMode )
         {
-            m_PlayMode->SetBitmap( guImage( forcegapless ? guIMAGE_INDEX_tiny_gapless : guIMAGE_INDEX_tiny_crossfade ) );
+            m_PlayMode->SetBitmap( guNS_Image::GetBitmap( forcegapless ? guIMAGE_INDEX_tiny_gapless : guIMAGE_INDEX_tiny_crossfade ) );
             m_PlayMode->SetToolTip( m_ForceGapless ? _( "Enable crossfading" ) : _( "Disable crossfading" ) );
             m_PlayMode->Refresh();
         }

--- a/src/TaListBox.cpp
+++ b/src/TaListBox.cpp
@@ -101,18 +101,18 @@ void guTaListBox::CreateContextMenu( wxMenu * Menu ) const
     wxMenuItem * MenuItem;
 
     MenuItem = new wxMenuItem( Menu, ID_LABEL_ADD, _( "Create" ), _( "Create a new label" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tags ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tags ) );
     Menu->Append( MenuItem );
 
 
     if( SelCount )
     {
         MenuItem = new wxMenuItem( Menu, ID_LABEL_EDIT, _( "Rename" ), _( "Change selected label" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_LABEL_DELETE, _( "Delete" ), _( "Delete selected labels" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
         Menu->Append( MenuItem );
     }
 
@@ -121,14 +121,14 @@ void guTaListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_LABEL_PLAY,
                             wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play current selected labels" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( Menu, ID_LABEL_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add current selected labels to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -137,21 +137,21 @@ void guTaListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( EnqueueMenu, ID_LABEL_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_LABEL_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_LABEL_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -164,7 +164,7 @@ void guTaListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_LABEL_SAVETOPLAYLIST,
                                 wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                                 _( "Save the selected tracks to playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         if( m_LibPanel->GetContextMenuFlags() & guCONTEXTMENU_COPY_TO )

--- a/src/TaskBar.cpp
+++ b/src/TaskBar.cpp
@@ -109,29 +109,29 @@ wxMenu * guTaskBarIcon::CreatePopupMenu()
     {
         bool IsPaused = ( m_PlayerPanel->GetState() == guMEDIASTATE_PLAYING );
         MenuItem = new wxMenuItem( Menu, ID_PLAYERPANEL_PLAY, IsPaused ? _( "Pause" ) : _( "Play" ), _( "Play current playlist" ) );
-        //MenuItem->SetBitmap( guImage( IsPaused ? guIMAGE_INDEX_player_normal_pause : guIMAGE_INDEX_player_normal_play ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( IsPaused ? guIMAGE_INDEX_player_normal_pause : guIMAGE_INDEX_player_normal_play ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_PLAYERPANEL_STOP, _( "Stop" ), _( "Play current playlist" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_normal_stop ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_stop ) );
         Menu->Append( MenuItem );
 
         Menu->AppendSeparator();
 
         MenuItem = new wxMenuItem( Menu, ID_PLAYERPANEL_NEXTTRACK, _( "Next Track" ), _( "Skip to next track in current playlist" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_normal_next ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_next ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_PLAYERPANEL_NEXTALBUM, _( "Next Album" ), _( "Skip to next album track in current playlist" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_normal_next ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_next ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_PLAYERPANEL_PREVTRACK, _( "Prev Track" ), _( "Skip to previous track in current playlist" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_normal_prev ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_prev ) );
         Menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( Menu, ID_PLAYERPANEL_PREVALBUM, _( "Prev Album" ), _( "Skip to previous album track in current playlist" ) );
-        //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_normal_prev ) );
+        //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_normal_prev ) );
         Menu->Append( MenuItem );
 
         Menu->AppendSeparator();
@@ -190,7 +190,7 @@ wxMenu * guTaskBarIcon::CreatePopupMenu()
     Menu->AppendSeparator();
 
     MenuItem = new wxMenuItem( Menu, ID_MENU_QUIT, _( "Exit" ), _( "Exit this program" ) );
-    //MenuItem->SetBitmap( guImage( guIMAGE_INDEX_playback_stop ) );
+    //MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_playback_stop ) );
     Menu->Append( MenuItem );
 
     return Menu;

--- a/src/TrackEdit.cpp
+++ b/src/TrackEdit.cpp
@@ -86,418 +86,418 @@ guTrackEditor::guTrackEditor( wxWindow * parent, guDbLibrary * db, guTrackArray 
 
 //	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 
-	wxBoxSizer * MainSizer = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer * MainSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_SongListSplitter = new wxSplitterWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_3D );
-	m_SongListSplitter->SetMinimumPaneSize( 150 );
+    m_SongListSplitter = new wxSplitterWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_3D );
+    m_SongListSplitter->SetMinimumPaneSize( 150 );
 
-	SongListPanel = new wxPanel( m_SongListSplitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    SongListPanel = new wxPanel( m_SongListSplitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
 
-	wxBoxSizer * SongsMainSizer = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer * SongsMainSizer = new wxBoxSizer( wxVERTICAL );
 
-	wxStaticBoxSizer * SongListSizer = new wxStaticBoxSizer( new wxStaticBox( SongListPanel, wxID_ANY, _( " Songs " ) ), wxHORIZONTAL );
+    wxStaticBoxSizer * SongListSizer = new wxStaticBoxSizer( new wxStaticBox( SongListPanel, wxID_ANY, _( " Songs " ) ), wxHORIZONTAL );
 
-	m_SongListBox = new wxListBox( SongListPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_SINGLE );
-	SongListSizer->Add( m_SongListBox, 1, wxALL|wxEXPAND, 2 );
+    m_SongListBox = new wxListBox( SongListPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_SINGLE );
+    SongListSizer->Add( m_SongListBox, 1, wxALL|wxEXPAND, 2 );
 
-	wxBoxSizer * OrderSizer = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer * OrderSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_MoveUpButton = new wxBitmapButton( SongListPanel, wxID_ANY, guImage( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_MoveUpButton = new wxBitmapButton( SongListPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_MoveUpButton->SetToolTip( _( "Move the track to the previous position" ) );
-	m_MoveUpButton->Enable( false );
+    m_MoveUpButton->Enable( false );
 
-	OrderSizer->Add( m_MoveUpButton, 0, wxALL, 2 );
+    OrderSizer->Add( m_MoveUpButton, 0, wxALL, 2 );
 
-	m_MoveDownButton = new wxBitmapButton( SongListPanel, wxID_ANY, guImage( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_MoveDownButton = new wxBitmapButton( SongListPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_MoveUpButton->SetToolTip( _( "Move the track to the next position" ) );
-	m_MoveDownButton->Enable( false );
-	OrderSizer->Add( m_MoveDownButton, 0, wxALL, 2 );
+    m_MoveDownButton->Enable( false );
+    OrderSizer->Add( m_MoveDownButton, 0, wxALL, 2 );
 
-	SongListSizer->Add( OrderSizer, 0, wxEXPAND, 5 );
+    SongListSizer->Add( OrderSizer, 0, wxEXPAND, 5 );
 
-	SongsMainSizer->Add( SongListSizer, 1, wxEXPAND|wxALL, 5 );
+    SongsMainSizer->Add( SongListSizer, 1, wxEXPAND|wxALL, 5 );
 
-	SongListPanel->SetSizer( SongsMainSizer );
-	SongListPanel->Layout();
-	SongListSizer->Fit( SongListPanel );
-	//MainDetailPanel = new wxPanel( m_SongListSplitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    SongListPanel->SetSizer( SongsMainSizer );
+    SongListPanel->Layout();
+    SongListSizer->Fit( SongListPanel );
+    //MainDetailPanel = new wxPanel( m_SongListSplitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
     wxScrolledWindow * MainDetailPanel = new wxScrolledWindow( m_SongListSplitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer * DetailSizer = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer * DetailSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_MainNotebook = new wxNotebook( MainDetailPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
+    m_MainNotebook = new wxNotebook( MainDetailPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
 
     //
     // Details
     //
-	wxPanel * DetailPanel = new wxPanel( m_MainNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxSizer * MainDetailSizer = new wxBoxSizer( wxVERTICAL );
+    wxPanel * DetailPanel = new wxPanel( m_MainNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxSizer * MainDetailSizer = new wxBoxSizer( wxVERTICAL );
 
     wxFlexGridSizer * DataFlexSizer = new wxFlexGridSizer( 3, 0, 0 );
-	DataFlexSizer->AddGrowableCol( 2 );
-	DataFlexSizer->SetFlexibleDirection( wxBOTH );
-	DataFlexSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    DataFlexSizer->AddGrowableCol( 2 );
+    DataFlexSizer->SetFlexibleDirection( wxBOTH );
+    DataFlexSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
-	m_ArCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_ArCopyButton->SetToolTip( _( "Copy the artist name to all the tracks you are editing" ) );
-	DataFlexSizer->Add( m_ArCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    m_ArCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_ArCopyButton->SetToolTip( _( "Copy the artist name to all the tracks you are editing" ) );
+    DataFlexSizer->Add( m_ArCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	ArStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Artist:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	ArStaticText->Wrap( -1 );
-	DataFlexSizer->Add( ArStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
+    ArStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Artist:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    ArStaticText->Wrap( -1 );
+    DataFlexSizer->Add( ArStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
 
     wxArrayString DummyArray;
-	m_ArtistComboBox = new wxComboBox( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, DummyArray, wxCB_DROPDOWN );
-	DataFlexSizer->Add( m_ArtistComboBox, 1, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
+    m_ArtistComboBox = new wxComboBox( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, DummyArray, wxCB_DROPDOWN );
+    DataFlexSizer->Add( m_ArtistComboBox, 1, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
 
-	m_AACopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_AACopyButton->SetToolTip( _( "Copy the album artist name to all the tracks you are editing" ) );
-	DataFlexSizer->Add( m_AACopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    m_AACopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_AACopyButton->SetToolTip( _( "Copy the album artist name to all the tracks you are editing" ) );
+    DataFlexSizer->Add( m_AACopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	wxStaticText * AAStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "A. Artist:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	AAStaticText->SetToolTip( _( "shows the album artist of the track" ) );
-	AAStaticText->Wrap( -1 );
-	DataFlexSizer->Add( AAStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
+    wxStaticText * AAStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "A. Artist:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    AAStaticText->SetToolTip( _( "shows the album artist of the track" ) );
+    AAStaticText->Wrap( -1 );
+    DataFlexSizer->Add( AAStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
 
-	m_AlbumArtistComboBox = new wxComboBox( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, DummyArray, wxCB_DROPDOWN );
-	DataFlexSizer->Add( m_AlbumArtistComboBox, 1, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
+    m_AlbumArtistComboBox = new wxComboBox( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, DummyArray, wxCB_DROPDOWN );
+    DataFlexSizer->Add( m_AlbumArtistComboBox, 1, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
 
-	m_AlCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_AlCopyButton->SetToolTip( _( "Copy the album name to all the tracks you are editing" ) );
-	DataFlexSizer->Add( m_AlCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    m_AlCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_AlCopyButton->SetToolTip( _( "Copy the album name to all the tracks you are editing" ) );
+    DataFlexSizer->Add( m_AlCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	AlStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Album:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	AlStaticText->Wrap( -1 );
-	DataFlexSizer->Add( AlStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
+    AlStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Album:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    AlStaticText->Wrap( -1 );
+    DataFlexSizer->Add( AlStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
 
-	m_AlbumComboBox = new wxComboBox( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, DummyArray, wxCB_DROPDOWN );
-	DataFlexSizer->Add( m_AlbumComboBox, 1, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
+    m_AlbumComboBox = new wxComboBox( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, DummyArray, wxCB_DROPDOWN );
+    DataFlexSizer->Add( m_AlbumComboBox, 1, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
 
-	m_TiCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_TiCopyButton->SetToolTip( _( "Copy the title to all the tracks you are editing" ) );
-	DataFlexSizer->Add( m_TiCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    m_TiCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_TiCopyButton->SetToolTip( _( "Copy the title to all the tracks you are editing" ) );
+    DataFlexSizer->Add( m_TiCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	TiStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Title:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	TiStaticText->Wrap( -1 );
-	DataFlexSizer->Add( TiStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
+    TiStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Title:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    TiStaticText->Wrap( -1 );
+    DataFlexSizer->Add( TiStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
 
-	m_TitleTextCtrl = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	DataFlexSizer->Add( m_TitleTextCtrl, 0, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
+    m_TitleTextCtrl = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    DataFlexSizer->Add( m_TitleTextCtrl, 0, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
 
-	m_CoCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_CoCopyButton->SetToolTip( _( "Copy the composer to all the tracks you are editing" ) );
-	DataFlexSizer->Add( m_CoCopyButton, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
+    m_CoCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_CoCopyButton->SetToolTip( _( "Copy the composer to all the tracks you are editing" ) );
+    DataFlexSizer->Add( m_CoCopyButton, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	wxStaticText * CoStaticText;
-	CoStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Composer:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	CoStaticText->Wrap( -1 );
-	DataFlexSizer->Add( CoStaticText, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    wxStaticText * CoStaticText;
+    CoStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Composer:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    CoStaticText->Wrap( -1 );
+    DataFlexSizer->Add( CoStaticText, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	m_CompComboBox = new wxComboBox( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, DummyArray, wxCB_DROPDOWN );
-	DataFlexSizer->Add( m_CompComboBox, 1, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
+    m_CompComboBox = new wxComboBox( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, DummyArray, wxCB_DROPDOWN );
+    DataFlexSizer->Add( m_CompComboBox, 1, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
 
-	m_CommentCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_CommentCopyButton->SetToolTip( _( "Copy the comment to all the tracks you are editing" ) );
-	DataFlexSizer->Add( m_CommentCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    m_CommentCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_CommentCopyButton->SetToolTip( _( "Copy the comment to all the tracks you are editing" ) );
+    DataFlexSizer->Add( m_CommentCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	wxStaticText * CommentStaticText;
-	CommentStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Comment:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	CommentStaticText->Wrap( -1 );
-	DataFlexSizer->Add( CommentStaticText, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    wxStaticText * CommentStaticText;
+    CommentStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Comment:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    CommentStaticText->Wrap( -1 );
+    DataFlexSizer->Add( CommentStaticText, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	m_CommentText = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( -1, 54 ), wxTE_MULTILINE );
-	DataFlexSizer->Add( m_CommentText, 1, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
+    m_CommentText = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( -1, 54 ), wxTE_MULTILINE );
+    DataFlexSizer->Add( m_CommentText, 1, wxALIGN_CENTER_VERTICAL|wxEXPAND|wxTOP|wxRIGHT, 5 );
 
 
-	m_NuCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_NuCopyButton->SetToolTip( _( "Copy the number to all the tracks you are editing" ) );
-	DataFlexSizer->Add( m_NuCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    m_NuCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_NuCopyButton->SetToolTip( _( "Copy the number to all the tracks you are editing" ) );
+    DataFlexSizer->Add( m_NuCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	NuStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Number:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	NuStaticText->Wrap( -1 );
-	DataFlexSizer->Add( NuStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
+    NuStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Number:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    NuStaticText->Wrap( -1 );
+    DataFlexSizer->Add( NuStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
 
 //	m_NumberTextCtrl = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
 //	DataFlexSizer->Add( m_NumberTextCtrl, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
 
-	wxBoxSizer* DiskSizer;
-	DiskSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer* DiskSizer;
+    DiskSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	m_NumberTextCtrl = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	DiskSizer->Add( m_NumberTextCtrl, 0, wxALIGN_CENTER_VERTICAL|wxTOP, 5 );
+    m_NumberTextCtrl = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    DiskSizer->Add( m_NumberTextCtrl, 0, wxALIGN_CENTER_VERTICAL|wxTOP, 5 );
 
-	m_NuOrderButton= new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_numerate ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_NuOrderButton->SetToolTip( _( "Enumerate the tracks in the order they were added for editing" ) );
-	DiskSizer->Add( m_NuOrderButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
+    m_NuOrderButton= new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_numerate ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_NuOrderButton->SetToolTip( _( "Enumerate the tracks in the order they were added for editing" ) );
+    DiskSizer->Add( m_NuOrderButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
 
-	DiskSizer->Add( 0, 0, 1, wxEXPAND, 5 );
+    DiskSizer->Add( 0, 0, 1, wxEXPAND, 5 );
 
-	m_DiCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_DiCopyButton->SetToolTip( _( "Copy the disk to all the tracks you are editing" ) );
-	DiskSizer->Add( m_DiCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    m_DiCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_DiCopyButton->SetToolTip( _( "Copy the disk to all the tracks you are editing" ) );
+    DiskSizer->Add( m_DiCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	wxStaticText * DiStaticText;
-	DiStaticText = new wxStaticText( DetailPanel, wxID_ANY, _("Disk:"), wxDefaultPosition, wxDefaultSize, 0 );
-	DiStaticText->Wrap( -1 );
-	DiskSizer->Add( DiStaticText, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
+    wxStaticText * DiStaticText;
+    DiStaticText = new wxStaticText( DetailPanel, wxID_ANY, _("Disk:"), wxDefaultPosition, wxDefaultSize, 0 );
+    DiStaticText->Wrap( -1 );
+    DiskSizer->Add( DiStaticText, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
 
-	m_DiskTextCtrl = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	DiskSizer->Add( m_DiskTextCtrl, 0, wxTOP|wxRIGHT, 5 );
+    m_DiskTextCtrl = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    DiskSizer->Add( m_DiskTextCtrl, 0, wxTOP|wxRIGHT, 5 );
 
-	DataFlexSizer->Add( DiskSizer, 1, wxEXPAND, 5 );
+    DataFlexSizer->Add( DiskSizer, 1, wxEXPAND, 5 );
 
-	m_GeCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_GeCopyButton->SetToolTip( _( "Copy the genre name to all songs you are editing" ) );
-	DataFlexSizer->Add( m_GeCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    m_GeCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_GeCopyButton->SetToolTip( _( "Copy the genre name to all songs you are editing" ) );
+    DataFlexSizer->Add( m_GeCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	GeStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Genre:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	GeStaticText->Wrap( -1 );
-	DataFlexSizer->Add( GeStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
+    GeStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Genre:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    GeStaticText->Wrap( -1 );
+    DataFlexSizer->Add( GeStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
 
-	m_GenreComboBox = new wxComboBox( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, DummyArray, wxCB_DROPDOWN );
-	DataFlexSizer->Add( m_GenreComboBox, 1, wxEXPAND|wxTOP|wxRIGHT|wxALIGN_CENTER_VERTICAL, 5 );
+    m_GenreComboBox = new wxComboBox( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, DummyArray, wxCB_DROPDOWN );
+    DataFlexSizer->Add( m_GenreComboBox, 1, wxEXPAND|wxTOP|wxRIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 
-	m_YeCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_YeCopyButton->SetToolTip( _( "Copy the year to all songs you are editing" ) );
-	DataFlexSizer->Add( m_YeCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    m_YeCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_YeCopyButton->SetToolTip( _( "Copy the year to all songs you are editing" ) );
+    DataFlexSizer->Add( m_YeCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	YeStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Year:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	YeStaticText->Wrap( -1 );
-	DataFlexSizer->Add( YeStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
+    YeStaticText = new wxStaticText( DetailPanel, wxID_ANY, _( "Year:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    YeStaticText->Wrap( -1 );
+    DataFlexSizer->Add( YeStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxRIGHT, 5 );
 
-	wxBoxSizer * RatingSizer;
-	RatingSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer * RatingSizer;
+    RatingSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	m_YearTextCtrl = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	RatingSizer->Add( m_YearTextCtrl, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxRIGHT, 5 );
+    m_YearTextCtrl = new wxTextCtrl( DetailPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    RatingSizer->Add( m_YearTextCtrl, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxRIGHT, 5 );
 
-	RatingSizer->Add( 0, 0, 1, wxEXPAND, 5 );
+    RatingSizer->Add( 0, 0, 1, wxEXPAND, 5 );
 
-	m_RaCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	RatingSizer->Add( m_RaCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    m_RaCopyButton = new wxBitmapButton( DetailPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    RatingSizer->Add( m_RaCopyButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-	wxStaticText * RaStaticText;
-	RaStaticText = new wxStaticText( DetailPanel, wxID_ANY, _("Rating:"), wxDefaultPosition, wxDefaultSize, 0 );
-	RaStaticText->Wrap( -1 );
-	RatingSizer->Add( RaStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxBOTTOM|wxRIGHT, 5 );
+    wxStaticText * RaStaticText;
+    RaStaticText = new wxStaticText( DetailPanel, wxID_ANY, _("Rating:"), wxDefaultPosition, wxDefaultSize, 0 );
+    RaStaticText->Wrap( -1 );
+    RatingSizer->Add( RaStaticText, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxTOP|wxBOTTOM|wxRIGHT, 5 );
 
     m_Rating = new guRating( DetailPanel, GURATING_STYLE_BIG );
-	RatingSizer->Add( m_Rating, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxRIGHT, 5 );
+    RatingSizer->Add( m_Rating, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxRIGHT, 5 );
 
-	DataFlexSizer->Add( RatingSizer, 1, wxEXPAND, 5 );
+    DataFlexSizer->Add( RatingSizer, 1, wxEXPAND, 5 );
 
-	MainDetailSizer->Add( DataFlexSizer, 0, wxEXPAND, 5 );
+    MainDetailSizer->Add( DataFlexSizer, 0, wxEXPAND, 5 );
 
-	wxBoxSizer* MoreDetailsSizer;
-	MoreDetailsSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer* MoreDetailsSizer;
+    MoreDetailsSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	m_DetailLeftInfoStaticText = new wxStaticText( DetailPanel, wxID_ANY, wxT("File Type\t:\nLength\t:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_DetailLeftInfoStaticText->Wrap( -1 );
-	MoreDetailsSizer->Add( m_DetailLeftInfoStaticText, 1, wxALL|wxEXPAND, 5 );
+    m_DetailLeftInfoStaticText = new wxStaticText( DetailPanel, wxID_ANY, wxT("File Type\t:\nLength\t:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_DetailLeftInfoStaticText->Wrap( -1 );
+    MoreDetailsSizer->Add( m_DetailLeftInfoStaticText, 1, wxALL|wxEXPAND, 5 );
 
-	m_DetailRightInfoStaticText = new wxStaticText( DetailPanel, wxID_ANY, wxT("BitRate\t:\nFileSize\t:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_DetailRightInfoStaticText->Wrap( -1 );
-	MoreDetailsSizer->Add( m_DetailRightInfoStaticText, 1, wxALL|wxEXPAND, 5 );
+    m_DetailRightInfoStaticText = new wxStaticText( DetailPanel, wxID_ANY, wxT("BitRate\t:\nFileSize\t:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_DetailRightInfoStaticText->Wrap( -1 );
+    MoreDetailsSizer->Add( m_DetailRightInfoStaticText, 1, wxALL|wxEXPAND, 5 );
 
-	MainDetailSizer->Add( MoreDetailsSizer, 1, wxEXPAND, 5 );
+    MainDetailSizer->Add( MoreDetailsSizer, 1, wxEXPAND, 5 );
 
-	DetailPanel->SetSizer( MainDetailSizer );
-	DetailPanel->Layout();
-	DataFlexSizer->Fit( DetailPanel );
-	m_MainNotebook->AddPage( DetailPanel, _( "Details" ), true );
+    DetailPanel->SetSizer( MainDetailSizer );
+    DetailPanel->Layout();
+    DataFlexSizer->Fit( DetailPanel );
+    m_MainNotebook->AddPage( DetailPanel, _( "Details" ), true );
 
-	//
-	// Pictures
-	//
-	PicturePanel = new wxPanel( m_MainNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* PictureSizer;
-	PictureSizer = new wxBoxSizer( wxVERTICAL );
+    //
+    // Pictures
+    //
+    PicturePanel = new wxPanel( m_MainNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* PictureSizer;
+    PictureSizer = new wxBoxSizer( wxVERTICAL );
 
-	wxStaticBoxSizer* PictureBitmapSizer;
-	PictureBitmapSizer = new wxStaticBoxSizer( new wxStaticBox( PicturePanel, wxID_ANY, wxEmptyString ), wxVERTICAL );
+    wxStaticBoxSizer* PictureBitmapSizer;
+    PictureBitmapSizer = new wxStaticBoxSizer( new wxStaticBox( PicturePanel, wxID_ANY, wxEmptyString ), wxVERTICAL );
 
-	m_PictureBitmap = new wxStaticBitmap( PicturePanel, wxID_ANY, wxNullBitmap, wxDefaultPosition, wxSize( 250,250 ), wxSUNKEN_BORDER );
-	PictureBitmapSizer->Add( m_PictureBitmap, 0, wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
+    m_PictureBitmap = new wxStaticBitmap( PicturePanel, wxID_ANY, wxNullBitmap, wxDefaultPosition, wxSize( 250,250 ), wxSUNKEN_BORDER );
+    PictureBitmapSizer->Add( m_PictureBitmap, 0, wxALL|wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	PictureSizer->Add( PictureBitmapSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
+    PictureSizer->Add( PictureBitmapSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
 
 
-	wxBoxSizer* PictureButtonSizer;
-	PictureButtonSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer* PictureButtonSizer;
+    PictureButtonSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	m_AddPicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_AddPicButton->SetToolTip( _( "Add a picture from file to the current track" ) );
-	PictureButtonSizer->Add( m_AddPicButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
+    m_AddPicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_AddPicButton->SetToolTip( _( "Add a picture from file to the current track" ) );
+    PictureButtonSizer->Add( m_AddPicButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
-	m_DelPicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_DelPicButton->SetToolTip( _( "Delete the picture from the current track" ) );
-	PictureButtonSizer->Add( m_DelPicButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
+    m_DelPicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_DelPicButton->SetToolTip( _( "Delete the picture from the current track" ) );
+    PictureButtonSizer->Add( m_DelPicButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
-	m_SavePicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_doc_save ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_SavePicButton->SetToolTip( _( "Save the current picture to file" ) );
-	PictureButtonSizer->Add( m_SavePicButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
+    m_SavePicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_SavePicButton->SetToolTip( _( "Save the current picture to file" ) );
+    PictureButtonSizer->Add( m_SavePicButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
-	m_SearchPicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_search ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_SearchPicButton->SetToolTip( _( "Search the album cover" ) );
-	PictureButtonSizer->Add( m_SearchPicButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
+    m_SearchPicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_SearchPicButton->SetToolTip( _( "Search the album cover" ) );
+    PictureButtonSizer->Add( m_SearchPicButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
-//	m_EditPicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guImage( guIMAGE_INDEX_edit ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+//	m_EditPicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_edit ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 //	PictureButtonSizer->Add( m_EditPicButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
 
-	PictureButtonSizer->Add( 10, 0, 0, wxEXPAND, 5 );
+    PictureButtonSizer->Add( 10, 0, 0, wxEXPAND, 5 );
 
-	m_CopyPicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
-	m_CopyPicButton->SetToolTip( _( "Copy the current picture to all the tracks you are editing" ) );
-	PictureButtonSizer->Add( m_CopyPicButton, 0, wxALL, 5 );
+    m_CopyPicButton = new wxBitmapButton( PicturePanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_copy ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_CopyPicButton->SetToolTip( _( "Copy the current picture to all the tracks you are editing" ) );
+    PictureButtonSizer->Add( m_CopyPicButton, 0, wxALL, 5 );
 
-	PictureSizer->Add( PictureButtonSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
+    PictureSizer->Add( PictureButtonSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
 
-	PicturePanel->SetSizer( PictureSizer );
-	PicturePanel->Layout();
-	PictureSizer->Fit( PicturePanel );
-	m_MainNotebook->AddPage( PicturePanel, _( "Pictures" ), false );
+    PicturePanel->SetSizer( PictureSizer );
+    PicturePanel->Layout();
+    PictureSizer->Fit( PicturePanel );
+    m_MainNotebook->AddPage( PicturePanel, _( "Pictures" ), false );
 
     //
     // Lyrics
     //
-	wxPanel * LyricsPanel = new wxPanel( m_MainNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer * LyricsSizer;
-	LyricsSizer = new wxBoxSizer( wxVERTICAL );
+    wxPanel * LyricsPanel = new wxPanel( m_MainNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer * LyricsSizer;
+    LyricsSizer = new wxBoxSizer( wxVERTICAL );
 
-	wxBoxSizer* LyricsTopSizer;
-	LyricsTopSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer* LyricsTopSizer;
+    LyricsTopSizer = new wxBoxSizer( wxHORIZONTAL );
 
-	wxStaticText * ArtistStaticText = new wxStaticText( LyricsPanel, wxID_ANY, _( "Artist:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	ArtistStaticText->Wrap( -1 );
-	LyricsTopSizer->Add( ArtistStaticText, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxLEFT, 5 );
+    wxStaticText * ArtistStaticText = new wxStaticText( LyricsPanel, wxID_ANY, _( "Artist:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    ArtistStaticText->Wrap( -1 );
+    LyricsTopSizer->Add( ArtistStaticText, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxLEFT, 5 );
 
-	m_LyricArtistTextCtrl = new wxTextCtrl( LyricsPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	LyricsTopSizer->Add( m_LyricArtistTextCtrl, 1, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
+    m_LyricArtistTextCtrl = new wxTextCtrl( LyricsPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    LyricsTopSizer->Add( m_LyricArtistTextCtrl, 1, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
 
-	wxStaticText * TrackStaticText = new wxStaticText( LyricsPanel, wxID_ANY, _( "Track:" ), wxDefaultPosition, wxDefaultSize, 0 );
-	TrackStaticText->Wrap( -1 );
-	LyricsTopSizer->Add( TrackStaticText, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxLEFT, 5 );
+    wxStaticText * TrackStaticText = new wxStaticText( LyricsPanel, wxID_ANY, _( "Track:" ), wxDefaultPosition, wxDefaultSize, 0 );
+    TrackStaticText->Wrap( -1 );
+    LyricsTopSizer->Add( TrackStaticText, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxLEFT, 5 );
 
-	m_LyricTrackTextCtrl = new wxTextCtrl( LyricsPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	LyricsTopSizer->Add( m_LyricTrackTextCtrl, 1, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
+    m_LyricTrackTextCtrl = new wxTextCtrl( LyricsPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    LyricsTopSizer->Add( m_LyricTrackTextCtrl, 1, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
 
-	m_LyricReloadButton = new wxBitmapButton( LyricsPanel, wxID_ANY, guImage( guIMAGE_INDEX_tiny_search_again ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_LyricReloadButton = new wxBitmapButton( LyricsPanel, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_search_again ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     m_LyricReloadButton->SetToolTip( _( "Search for lyrics" ) );
-	LyricsTopSizer->Add( m_LyricReloadButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
+    LyricsTopSizer->Add( m_LyricReloadButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT|wxLEFT, 5 );
 
-	LyricsSizer->Add( LyricsTopSizer, 0, wxEXPAND, 5 );
-
-
-	m_LyricsTextCtrl = new wxTextCtrl( LyricsPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_CENTRE|wxTE_DONTWRAP|wxTE_MULTILINE );
-	LyricsSizer->Add( m_LyricsTextCtrl, 1, wxALL|wxEXPAND, 5 );
-
-	LyricsPanel->SetSizer( LyricsSizer );
-	LyricsPanel->Layout();
-	LyricsSizer->Fit( LyricsPanel );
-	m_MainNotebook->AddPage( LyricsPanel, _( "Lyrics" ), false );
+    LyricsSizer->Add( LyricsTopSizer, 0, wxEXPAND, 5 );
 
 
-	DetailSizer->Add( m_MainNotebook, 1, wxEXPAND | wxALL, 5 );
+    m_LyricsTextCtrl = new wxTextCtrl( LyricsPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_CENTRE|wxTE_DONTWRAP|wxTE_MULTILINE );
+    LyricsSizer->Add( m_LyricsTextCtrl, 1, wxALL|wxEXPAND, 5 );
 
-	MainDetailPanel->SetSizer( DetailSizer );
-	MainDetailPanel->Layout();
-	DetailSizer->Fit( MainDetailPanel );
-	m_SongListSplitter->SplitVertically( SongListPanel, MainDetailPanel, 200 );
-	MainSizer->Add( m_SongListSplitter, 1, wxEXPAND, 5 );
+    LyricsPanel->SetSizer( LyricsSizer );
+    LyricsPanel->Layout();
+    LyricsSizer->Fit( LyricsPanel );
+    m_MainNotebook->AddPage( LyricsPanel, _( "Lyrics" ), false );
+
+
+    DetailSizer->Add( m_MainNotebook, 1, wxEXPAND | wxALL, 5 );
+
+    MainDetailPanel->SetSizer( DetailSizer );
+    MainDetailPanel->Layout();
+    DetailSizer->Fit( MainDetailPanel );
+    m_SongListSplitter->SplitVertically( SongListPanel, MainDetailPanel, 200 );
+    MainSizer->Add( m_SongListSplitter, 1, wxEXPAND, 5 );
 
     wxStdDialogButtonSizer *    ButtonsSizer;
     wxButton *                  ButtonsSizerOK;
     wxButton *                  ButtonsSizerCancel;
-	ButtonsSizer = new wxStdDialogButtonSizer();
-	ButtonsSizerOK = new wxButton( this, wxID_OK );
-	ButtonsSizer->AddButton( ButtonsSizerOK );
-	ButtonsSizerCancel = new wxButton( this, wxID_CANCEL );
-	ButtonsSizer->AddButton( ButtonsSizerCancel );
-	ButtonsSizer->SetAffirmativeButton( ButtonsSizerOK );
-	ButtonsSizer->SetCancelButton( ButtonsSizerCancel );
-	ButtonsSizer->Realize();
-	MainSizer->Add( ButtonsSizer, 0, wxEXPAND|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
+    ButtonsSizer = new wxStdDialogButtonSizer();
+    ButtonsSizerOK = new wxButton( this, wxID_OK );
+    ButtonsSizer->AddButton( ButtonsSizerOK );
+    ButtonsSizerCancel = new wxButton( this, wxID_CANCEL );
+    ButtonsSizer->AddButton( ButtonsSizerCancel );
+    ButtonsSizer->SetAffirmativeButton( ButtonsSizerOK );
+    ButtonsSizer->SetCancelButton( ButtonsSizerCancel );
+    ButtonsSizer->Realize();
+    MainSizer->Add( ButtonsSizer, 0, wxEXPAND|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
-	this->SetSizer( MainSizer );
-	this->Layout();
+    this->SetSizer( MainSizer );
+    this->Layout();
 
-	MainDetailPanel->SetScrollRate( 20, 20 );
-
-
-	ButtonsSizerOK->SetDefault();
+    MainDetailPanel->SetScrollRate( 20, 20 );
 
 
-	// --------------------------------------------------------------------
+    ButtonsSizerOK->SetDefault();
+
+
+    // --------------------------------------------------------------------
     m_NormalColor = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT );
     m_ErrorColor = wxSystemSettings::GetColour( wxSYS_COLOUR_HIGHLIGHT );
-	m_CurItem = 0;
-	m_NextItem = wxNOT_FOUND;
-	m_Items = songs;
-	m_Images = images;
-	m_Lyrics = lyrics;
-	m_ChangedFlags = changedflags;
-	m_CurrentRating = -1;
-	m_RatingChanged = false;
-	m_GenreChanged = false;
-	wxArrayString ItemsText;
-	count = m_Items->Count();
-	for( index = 0; index < count; index++ )
-	{
+    m_CurItem = 0;
+    m_NextItem = wxNOT_FOUND;
+    m_Items = songs;
+    m_Images = images;
+    m_Lyrics = lyrics;
+    m_ChangedFlags = changedflags;
+    m_CurrentRating = -1;
+    m_RatingChanged = false;
+    m_GenreChanged = false;
+    wxArrayString ItemsText;
+    count = m_Items->Count();
+    for( index = 0; index < count; index++ )
+    {
         ItemsText.Add( ( * m_Items )[ index ].m_FileName );
         // Fill the initial Images of the files
         m_Images->Add( guTagGetPicture( ( * m_Items )[ index ].m_FileName ) );
         m_Lyrics->Add( guTagGetLyrics( ( * m_Items )[ index ].m_FileName ) );
         m_ChangedFlags->Add( guTRACK_CHANGED_DATA_NONE );
-	}
-	m_SongListBox->InsertItems( ItemsText, 0 );
-	m_SongListBox->SetFocus();
+    }
+    m_SongListBox->InsertItems( ItemsText, 0 );
+    m_SongListBox->SetFocus();
 
-	// Connect Events
-	Connect( wxID_OK, wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnOKButton ) );
-	m_MainNotebook->Connect( wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, wxNotebookEventHandler( guTrackEditor::OnPageChanged ), NULL, this );
+    // Connect Events
+    Connect( wxID_OK, wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnOKButton ) );
+    m_MainNotebook->Connect( wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, wxNotebookEventHandler( guTrackEditor::OnPageChanged ), NULL, this );
 
-	m_SongListBox->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( guTrackEditor::OnSongListBoxSelected ), NULL, this );
-	m_MoveUpButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnMoveUpBtnClick ), NULL, this );
-	m_MoveDownButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnMoveDownBtnClick ), NULL, this );
-	m_ArCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnArCopyButtonClicked ), NULL, this );
-	m_AACopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnAACopyButtonClicked ), NULL, this );
-	m_AlCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnAlCopyButtonClicked ), NULL, this );
-	m_TiCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnTiCopyButtonClicked ), NULL, this );
-	m_CoCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnCoCopyButtonClicked ), NULL, this );
-	m_NuCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnNuCopyButtonClicked ), NULL, this );
-	m_NuOrderButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnNuOrderButtonClicked ), NULL, this );
-	m_DiCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnDiCopyButtonClicked ), NULL, this );
-	m_GeCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnGeCopyButtonClicked ), NULL, this );
-	m_YeCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnYeCopyButtonClicked ), NULL, this );
-	m_RaCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnRaCopyButtonClicked ), NULL, this );
+    m_SongListBox->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( guTrackEditor::OnSongListBoxSelected ), NULL, this );
+    m_MoveUpButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnMoveUpBtnClick ), NULL, this );
+    m_MoveDownButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnMoveDownBtnClick ), NULL, this );
+    m_ArCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnArCopyButtonClicked ), NULL, this );
+    m_AACopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnAACopyButtonClicked ), NULL, this );
+    m_AlCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnAlCopyButtonClicked ), NULL, this );
+    m_TiCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnTiCopyButtonClicked ), NULL, this );
+    m_CoCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnCoCopyButtonClicked ), NULL, this );
+    m_NuCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnNuCopyButtonClicked ), NULL, this );
+    m_NuOrderButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnNuOrderButtonClicked ), NULL, this );
+    m_DiCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnDiCopyButtonClicked ), NULL, this );
+    m_GeCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnGeCopyButtonClicked ), NULL, this );
+    m_YeCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnYeCopyButtonClicked ), NULL, this );
+    m_RaCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnRaCopyButtonClicked ), NULL, this );
     m_Rating->Connect( guEVT_RATING_CHANGED, guRatingEventHandler( guTrackEditor::OnRatingChanged ), NULL, this );
-	m_CommentCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnCommentCopyButtonClicked ), NULL, this );
+    m_CommentCopyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnCommentCopyButtonClicked ), NULL, this );
 
-	m_ArtistComboBox->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnArtistTextChanged ), NULL, this );
-	m_AlbumArtistComboBox->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnAlbumArtistTextChanged ), NULL, this );
-	m_AlbumComboBox->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnAlbumTextChanged ), NULL, this );
-	m_CompComboBox->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnComposerTextChanged ), NULL, this );
-	m_GenreComboBox->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnGenreTextChanged ), NULL, this );
+    m_ArtistComboBox->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnArtistTextChanged ), NULL, this );
+    m_AlbumArtistComboBox->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnAlbumArtistTextChanged ), NULL, this );
+    m_AlbumComboBox->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnAlbumTextChanged ), NULL, this );
+    m_CompComboBox->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnComposerTextChanged ), NULL, this );
+    m_GenreComboBox->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnGenreTextChanged ), NULL, this );
 
-	m_AddPicButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnAddImageClicked ), NULL, this );
-	m_DelPicButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnDelImageClicked ), NULL, this );
-	m_SavePicButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnSaveImageClicked ), NULL, this );
-	m_SearchPicButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnSearchImageClicked ), NULL, this );
-	m_CopyPicButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnCopyImageClicked ), NULL, this );
+    m_AddPicButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnAddImageClicked ), NULL, this );
+    m_DelPicButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnDelImageClicked ), NULL, this );
+    m_SavePicButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnSaveImageClicked ), NULL, this );
+    m_SearchPicButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnSearchImageClicked ), NULL, this );
+    m_CopyPicButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnCopyImageClicked ), NULL, this );
 
-	m_LyricReloadButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnSearchLyrics ), NULL, this );
-	m_LyricArtistTextCtrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnTextUpdated ), NULL, this );
-	m_LyricTrackTextCtrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnTextUpdated ), NULL, this );
+    m_LyricReloadButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( guTrackEditor::OnSearchLyrics ), NULL, this );
+    m_LyricArtistTextCtrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnTextUpdated ), NULL, this );
+    m_LyricTrackTextCtrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( guTrackEditor::OnTextUpdated ), NULL, this );
 
     Connect( ID_LYRICS_LYRICFOUND, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( guTrackEditor::OnDownloadedLyric ), NULL, this );
 
     // Idle Events
-	m_SongListSplitter->Connect( wxEVT_IDLE, wxIdleEventHandler( guTrackEditor::SongListSplitterOnIdle ), NULL, this );
+    m_SongListSplitter->Connect( wxEVT_IDLE, wxIdleEventHandler( guTrackEditor::SongListSplitterOnIdle ), NULL, this );
 
-	Connect( wxEVT_TIMER, wxTimerEventHandler( guTrackEditor::OnSelectTimeout ), NULL, this );
+    Connect( wxEVT_TIMER, wxTimerEventHandler( guTrackEditor::OnSelectTimeout ), NULL, this );
 
-	//
+    //
     // Force the 1st listbox item to be selected
-	m_SongListBox->SetSelection( 0 );
+    m_SongListBox->SetSelection( 0 );
 //    wxCommandEvent event( wxEVT_COMMAND_LISTBOX_SELECTED, m_SongListBox->GetId() );
 //    event.SetEventObject( m_SongListBox );
 //    event.SetExtraLong( 1 );
@@ -1014,7 +1014,7 @@ void guTrackEditor::RefreshImage( void )
     }
     else
     {
-        Image = guImage( guIMAGE_INDEX_no_cover );
+        Image = guNS_Image::GetImage( guIMAGE_INDEX_no_cover );
     }
     Image.Rescale( 250, 250, wxIMAGE_QUALITY_HIGH );
     m_PictureBitmap->SetBitmap( Image );

--- a/src/TreePanel.cpp
+++ b/src/TreePanel.cpp
@@ -79,8 +79,8 @@ guTreeViewTreeCtrl::guTreeViewTreeCtrl( wxWindow * parent, guDbLibrary * db, guT
     }
 
     m_ImageList = new wxImageList();
-    m_ImageList->Add( wxBitmap( guImage( guIMAGE_INDEX_track ) ) );
-    m_ImageList->Add( wxBitmap( guImage( guIMAGE_INDEX_filter ) ) );
+    m_ImageList->Add( wxBitmap( guNS_Image::GetImage( guIMAGE_INDEX_track ) ) );
+    m_ImageList->Add( wxBitmap( guNS_Image::GetImage( guIMAGE_INDEX_filter ) ) );
     AssignImageList( m_ImageList );
 
     m_RootId   = AddRoot( wxT( "Sortings" ), -1, -1, NULL );
@@ -364,15 +364,15 @@ void guTreeViewTreeCtrl::OnContextMenu( wxTreeEvent &event )
         if( ItemId == m_FiltersId || GetItemParent( ItemId ) == m_FiltersId )
         {
             MenuItem = new wxMenuItem( &Menu, ID_TREEVIEW_FILTER_NEW, _( "Create" ), _( "Create a new filter" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
             Menu.Append( MenuItem );
 
             MenuItem = new wxMenuItem( &Menu, ID_TREEVIEW_FILTER_EDIT, _( "Edit" ), _( "Edit the selected filter" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu.Append( MenuItem );
 
             MenuItem = new wxMenuItem( &Menu, ID_TREEVIEW_FILTER_DELETE, _( "Delete" ), _( "Delete the selected filter" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
             Menu.Append( MenuItem );
 
             Menu.AppendSeparator();
@@ -385,13 +385,13 @@ void guTreeViewTreeCtrl::OnContextMenu( wxTreeEvent &event )
                 int ContextMenuFlags = GetContextMenuFlags();
 
                 MenuItem = new wxMenuItem( &Menu, ID_TREEVIEW_PLAY, _( "Play" ), _( "Play current selected songs" ) );
-                MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+                MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
                 Menu.Append( MenuItem );
 
                 MenuItem = new wxMenuItem( &Menu, ID_TREEVIEW_ENQUEUE_AFTER_ALL,
                                 wxString( _( "Enqueue" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                                 _( "Add current selected songs to the playlist" ) );
-                MenuItem->SetBitmap( guImage( guIMAGE_INDEX_add ) );
+                MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_add ) );
                 Menu.Append( MenuItem );
 
                 wxMenu * EnqueueMenu = new wxMenu();
@@ -399,19 +399,19 @@ void guTreeViewTreeCtrl::OnContextMenu( wxTreeEvent &event )
                 MenuItem = new wxMenuItem( EnqueueMenu, ID_TREEVIEW_ENQUEUE_AFTER_TRACK,
                                         wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                                         _( "Add current selected tracks to playlist after the current track" ) );
-                MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+                MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
                 EnqueueMenu->Append( MenuItem );
 
                 MenuItem = new wxMenuItem( EnqueueMenu, ID_TREEVIEW_ENQUEUE_AFTER_ALBUM,
                                         wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                                         _( "Add current selected tracks to playlist after the current album" ) );
-                MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+                MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
                 EnqueueMenu->Append( MenuItem );
 
                 MenuItem = new wxMenuItem( EnqueueMenu, ID_TREEVIEW_ENQUEUE_AFTER_ARTIST,
                                         wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                                         _( "Add current selected tracks to playlist after the current artist" ) );
-                MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+                MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
                 EnqueueMenu->Append( MenuItem );
 
                 Menu.Append( wxID_ANY, _( "Enqueue After" ), EnqueueMenu );
@@ -428,7 +428,7 @@ void guTreeViewTreeCtrl::OnContextMenu( wxTreeEvent &event )
                         MenuItem = new wxMenuItem( &Menu, ID_TREEVIEW_EDITLABELS,
                                                 wxString( _( "Edit Labels" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITLABELS ),
                                                 _( "Edit the labels assigned to the selected items" ) );
-                        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tags ) );
+                        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tags ) );
                         Menu.Append( MenuItem );
                     }
                 }
@@ -438,7 +438,7 @@ void guTreeViewTreeCtrl::OnContextMenu( wxTreeEvent &event )
                     MenuItem = new wxMenuItem( &Menu, ID_TREEVIEW_EDITTRACKS,
                                         wxString( _( "Edit Songs" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                                         _( "Edit the selected tracks" ) );
-                    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+                    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
                     Menu.Append( MenuItem );
                 }
 
@@ -447,7 +447,7 @@ void guTreeViewTreeCtrl::OnContextMenu( wxTreeEvent &event )
                 MenuItem = new wxMenuItem( &Menu, ID_TREEVIEW_SAVETOPLAYLIST,
                                         wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                                         _( "Save the selected tracks to playlist" ) );
-                MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+                MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
                 Menu.Append( MenuItem );
 
                 if( ( ContextMenuFlags & guCONTEXTMENU_COPY_TO ) ||

--- a/src/TreeViewFilterEditor.cpp
+++ b/src/TreeViewFilterEditor.cpp
@@ -92,17 +92,17 @@ guTreeViewFilterEditor::guTreeViewFilterEditor( wxWindow * parent, const wxStrin
 
 	wxBoxSizer * FilterButtonsSizer = new wxBoxSizer( wxVERTICAL );
 
-	m_UpFilterButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_UpFilterButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_up ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_UpFilterButton->Enable( false );
 
 	FilterButtonsSizer->Add( m_UpFilterButton, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
 
-	m_DownFilterButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_DownFilterButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_down ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_DownFilterButton->Enable( false );
 
 	FilterButtonsSizer->Add( m_DownFilterButton, 0, wxALIGN_CENTER_HORIZONTAL|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
-	m_DelFilterButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_DelFilterButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_del ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_DelFilterButton->Enable( false );
 
 	FilterButtonsSizer->Add( m_DelFilterButton, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
@@ -125,7 +125,7 @@ guTreeViewFilterEditor::guTreeViewFilterEditor( wxWindow * parent, const wxStrin
 	m_FiltersChoice->SetSelection( 0 );
 	NewFilterSizer->Add( m_FiltersChoice, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxRIGHT, 5 );
 
-	m_AddFilterButton = new wxBitmapButton( this, wxID_ANY, guImage( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+	m_AddFilterButton = new wxBitmapButton( this, wxID_ANY, guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	NewFilterSizer->Add( m_AddFilterButton, 0, wxTOP|wxRIGHT, 5 );
 
 	FiltersSizer->Add( NewFilterSizer, 0, wxEXPAND, 5 );

--- a/src/TuneInRadio.cpp
+++ b/src/TuneInRadio.cpp
@@ -53,7 +53,7 @@ bool guTuneInRadioProvider::OnContextMenu( wxMenu * menu, const wxTreeItemId &it
 // -------------------------------------------------------------------------------- //
 void guTuneInRadioProvider::RegisterImages( wxImageList * imagelist )
 {
-    imagelist->Add( guImage( guIMAGE_INDEX_tiny_tunein ) );
+    imagelist->Add( guNS_Image::GetImage( guIMAGE_INDEX_tiny_tunein ) );
     m_ImageIds.Add( imagelist->GetImageCount() - 1 );
 }
 

--- a/src/UserRadio.cpp
+++ b/src/UserRadio.cpp
@@ -52,7 +52,7 @@ bool guUserRadioProvider::OnContextMenu( wxMenu * menu, const wxTreeItemId &item
         menu->AppendSeparator();
 
     wxMenuItem * MenuItem = new wxMenuItem( menu, ID_RADIO_USER_ADD, _( "Add Radio" ), _( "Create a new radio" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     menu->Append( MenuItem );
 
     if( forstations && selcount )
@@ -60,22 +60,22 @@ bool guUserRadioProvider::OnContextMenu( wxMenu * menu, const wxTreeItemId &item
         MenuItem = new wxMenuItem( menu, ID_RADIO_USER_EDIT,
                         wxString( _( "Edit Radio" ) ) + guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                         _( "Change the selected radio" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
         menu->Append( MenuItem );
 
         MenuItem = new wxMenuItem( menu, ID_RADIO_USER_DEL, _( "Delete Radio" ), _( "Delete the selected radio" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit_clear ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit_clear ) );
         menu->Append( MenuItem );
     }
 
     menu->AppendSeparator();
 
     MenuItem = new wxMenuItem( menu, ID_RADIO_USER_IMPORT, _( "Import" ), _( "Import the radio stations" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     menu->Append( MenuItem );
 
     MenuItem = new wxMenuItem( menu, ID_RADIO_USER_EXPORT, _( "Export" ), _( "Export all the radio stations" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
     menu->Append( MenuItem );
 
     return true;
@@ -94,7 +94,7 @@ void guUserRadioProvider::SetSearchText( const wxArrayString &texts )
 // -------------------------------------------------------------------------------- //
 void guUserRadioProvider::RegisterImages( wxImageList * imagelist )
 {
-    imagelist->Add( guImage( guIMAGE_INDEX_tiny_net_radio ) );
+    imagelist->Add( guNS_Image::GetImage( guIMAGE_INDEX_tiny_net_radio ) );
     m_ImageIds.Add( imagelist->GetImageCount() - 1 );
 }
 

--- a/src/YeListBox.cpp
+++ b/src/YeListBox.cpp
@@ -101,14 +101,14 @@ void guYeListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( Menu, ID_YEAR_PLAY,
                             wxString( _( "Play" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_PLAY ),
                             _( "Play current selected artists" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_player_tiny_light_play ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_player_tiny_light_play ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( Menu, ID_YEAR_ENQUEUE_AFTER_ALL,
                             wxString( _( "Enqueue" ) ) + guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALL ),
                             _( "Add current selected tracks to playlist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     Menu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -117,21 +117,21 @@ void guYeListBox::CreateContextMenu( wxMenu * Menu ) const
     MenuItem = new wxMenuItem( EnqueueMenu, ID_YEAR_ENQUEUE_AFTER_TRACK,
                             wxString( _( "Current Track" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_TRACK ),
                             _( "Add current selected tracks to playlist after the current track" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_YEAR_ENQUEUE_AFTER_ALBUM,
                             wxString( _( "Current Album" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ALBUM ),
                             _( "Add current selected tracks to playlist after the current album" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
     MenuItem = new wxMenuItem( EnqueueMenu, ID_YEAR_ENQUEUE_AFTER_ARTIST,
                             wxString( _( "Current Artist" ) ) +  guAccelGetCommandKeyCodeString( ID_TRACKS_ENQUEUE_AFTER_ARTIST ),
                             _( "Add current selected tracks to playlist after the current artist" ) );
-    MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_add ) );
+    MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_add ) );
     EnqueueMenu->Append( MenuItem );
     MenuItem->Enable( SelCount );
 
@@ -146,7 +146,7 @@ void guYeListBox::CreateContextMenu( wxMenu * Menu ) const
             MenuItem = new wxMenuItem( Menu, ID_YEAR_EDITTRACKS,
                                 wxString( _( "Edit Songs" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_EDITTRACKS ),
                                 _( "Edit the selected tracks" ) );
-            MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_edit ) );
+            MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_edit ) );
             Menu->Append( MenuItem );
         }
 
@@ -155,7 +155,7 @@ void guYeListBox::CreateContextMenu( wxMenu * Menu ) const
         MenuItem = new wxMenuItem( Menu, ID_YEAR_SAVETOPLAYLIST,
                                 wxString( _( "Save to Playlist" ) ) +  guAccelGetCommandKeyCodeString( ID_PLAYER_PLAYLIST_SAVE ),
                                 _( "Save the selected tracks to Playlist" ) );
-        MenuItem->SetBitmap( guImage( guIMAGE_INDEX_tiny_doc_save ) );
+        MenuItem->SetBitmap( guNS_Image::GetBitmap( guIMAGE_INDEX_tiny_doc_save ) );
         Menu->Append( MenuItem );
 
         if( ContextMenuFlags & guCONTEXTMENU_COPY_TO )


### PR DESCRIPTION
```gu*``` is used as an indicator of guayadeque object. Change the references to ```guImage``` and ```guBitmap``` to indicate they are functions and not objects.

Too often there is code that will accept a wxBitmap but is given a wxBitmap converted to a wxImage, which is internally converted to a wxBitmap. This is mostly seen in context menus and wxBitmapButton type classes. Creation of these objects is given a wxBitmap directly.

Array index of image data (see src/Images.cpp) is dangerously dependent on its position in the array.
Changes made to explicitly associate imaged data to its index value. (use std::map)

guRoundButton and guRoundToggleButton classes were not touched. Classes take wxImage as a parameter but use wxBitmap internally.

Code clean up to fix some indentations