### PR TITLE
Make it possible to jump albums via MPRIS.

### DIFF
--- a/src/dbus/mpris.cpp
+++ b/src/dbus/mpris.cpp
@@ -64,6 +64,10 @@ const char * Introspection_XML_Data_Player =
 "    </method>\n"
 "    <method name=\"Prev\">\n"
 "    </method>\n"
+"    <method name=\"NextAlbum\">\n" // Non-standard
+"    </method>\n"
+"    <method name=\"PrevAlbum\">\n" // Non-standard
+"    </method>\n"
 "    <method name=\"Pause\">\n"
 "    </method>\n"
 "    <method name=\"Stop\">\n"
@@ -429,6 +433,22 @@ DBusHandlerResult guMPRIS::HandleMessages( guDBusMessage * msg, guDBusMessage * 
                 else if( !strcmp( Member, "Prev" ) )
                 {
                     wxCommandEvent event( wxEVT_MENU, ID_PLAYERPANEL_PREVTRACK );
+                    wxPostEvent( m_PlayerPanel, event );
+                    Send( reply );
+                    Flush();
+                    RetVal = DBUS_HANDLER_RESULT_HANDLED;
+                }
+                else if( !strcmp( Member, "NextAlbum" ) )
+                {
+                    wxCommandEvent event( wxEVT_MENU, ID_PLAYERPANEL_NEXTALBUM );
+                    wxPostEvent( m_PlayerPanel, event );
+                    Send( reply );
+                    Flush();
+                    RetVal = DBUS_HANDLER_RESULT_HANDLED;
+                }
+                else if( !strcmp( Member, "PrevAlbum" ) )
+                {
+                    wxCommandEvent event( wxEVT_MENU, ID_PLAYERPANEL_PREVALBUM );
                     wxPostEvent( m_PlayerPanel, event );
                     Send( reply );
                     Flush();

--- a/src/dbus/mpris2.cpp
+++ b/src/dbus/mpris2.cpp
@@ -58,7 +58,9 @@ const char * guMPRIS2_INTROSPECTION_XML =
 	"  </interface>\n"
 	"  <interface name='org.mpris.MediaPlayer2.Player'>\n"
 	"    <method name='Next'/>\n"
+	"    <method name='NextAlbum'/>\n" // Non-standard
 	"    <method name='Previous'/>\n"
+	"    <method name='PreviousAlbum'/>\n" // Non-standard
 	"    <method name='Pause'/>\n"
 	"    <method name='PlayPause'/>\n"
 	"    <method name='Stop'/>\n"
@@ -1535,6 +1537,22 @@ DBusHandlerResult guMPRIS2::HandleMessages( guDBusMessage * msg, guDBusMessage *
                 else if( !strcmp( Member, "Previous" ) )
                 {
                     wxCommandEvent event( wxEVT_MENU, ID_PLAYERPANEL_PREVTRACK );
+                    wxPostEvent( m_PlayerPanel, event );
+                    Send( reply );
+                    Flush();
+                    RetVal = DBUS_HANDLER_RESULT_HANDLED;
+                }
+                else if( !strcmp( Member, "NextAlbum" ) )
+                {
+                    wxCommandEvent event( wxEVT_MENU, ID_PLAYERPANEL_NEXTALBUM );
+                    wxPostEvent( m_PlayerPanel, event );
+                    Send( reply );
+                    Flush();
+                    RetVal = DBUS_HANDLER_RESULT_HANDLED;
+                }
+                else if( !strcmp( Member, "PreviousAlbum" ) )
+                {
+                    wxCommandEvent event( wxEVT_MENU, ID_PLAYERPANEL_PREVALBUM );
                     wxPostEvent( m_PlayerPanel, event );
                     Send( reply );
                     Flush();


### PR DESCRIPTION
This adds non-standard MPRIS interface calls for next/prev albums.

MPRIS1:
org.freedesktop.MediaPlayer.NextAlbum
org.freedesktop.MediaPlayer.PrevAlbum

MPRIS2:
org.mpris.MediaPlayer2.Player.NextAlbum
org.mpris.MediaPlayer2.Player.PreviousAlbum

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>