### PR TITLE
Fix two segfaults 

### DIFF
--- a/src/MainApp.cpp
+++ b/src/MainApp.cpp
@@ -47,6 +47,7 @@ guMainApp::guMainApp() : wxApp()
 {
 //    m_Db = NULL;
     m_DbCache = NULL;
+    m_SingleInstanceChecker = nullptr;
 
 #if wxUSE_ON_FATAL_EXCEPTION    // Thanks TheBigRed
         wxHandleFatalExceptions();

--- a/src/dbus/gsession.cpp
+++ b/src/dbus/gsession.cpp
@@ -65,7 +65,7 @@ guGSession::guGSession( guDBusServer * server ) : guDBusClient( server )
 // -------------------------------------------------------------------------------- //
 guGSession::~guGSession()
 {
-    if( !m_ObjectPath.IsEmpty() )
+    if( !m_ObjectPath.IsEmpty() && m_Status == guGSESSION_STATUS_INITIALIZED )
     {
         guDBusMethodCall * Msg = new guDBusMethodCall( "org.gnome.SessionManager",
 			"/org/gnome/SessionManager",


### PR DESCRIPTION
Hi,

Guayadeque is my favorite music player for a long time, thanks for that amazing piece of software !

I've fixed two segfault by doing minor change to the code, so I think there won't be any side effect even if I've not a good knowledge about the Guayadeque code base.

The first fix a problem with `wxSingleInstanceChecker` by just setting `m_SingleInstanceChecker` to NULL and avoid calling `delete m_SingleInstanceChecker` that crash the app if `m_SingleInstanceChecker` hasn't been correctly init before.

The second fix a minor segfault because it appears only when you leave the app without had played any tracks. So now the dbus method which unregister the player is called only if it has been init before.

I hope that there will be someone to take care of Guayadeque in the future because it's really the best music player for Linux i've found in decades !