### PR TITLE
File format in playerpanel: store in playlist, hide if not set

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -692,6 +692,7 @@ void WriteTrack( wxXmlNode * xmlnode, const guTrack &track )
     WriteStr( XmlNode, wxT( "Album" ), track.m_AlbumName );
     WriteStr( XmlNode, wxT( "Path" ), track.m_Path );
     WriteStr( XmlNode, wxT( "FileName" ), track.m_FileName );
+    WriteStr( XmlNode, wxT( "Format" ), track.m_Format );
     WriteStr( XmlNode, wxT( "Number" ), wxString::Format( wxT( "%i" ), track.m_Number ) );
     WriteStr( XmlNode, wxT( "Rating" ), wxString::Format( wxT( "%i" ), track.m_Rating ) );
     WriteStr( XmlNode, wxT( "Offset" ), wxString::Format( wxT( "%u" ), track.m_Offset ) );
@@ -750,6 +751,10 @@ void ReadTrack( wxXmlNode * xmlnode, guTrack &track )
         else if( Name == wxT( "FileName" ) )
         {
             xmlnode->GetAttribute( wxT( "value" ), &track.m_FileName );
+        }
+        else if( Name == wxT( "Format" ) )
+        {
+            xmlnode->GetAttribute( wxT( "value" ), &track.m_Format );
         }
         else if( Name == wxT( "Number" ) )
         {

--- a/src/ui/player/PlayerPanel.cpp
+++ b/src/ui/player/PlayerPanel.cpp
@@ -756,7 +756,13 @@ void guPlayerPanel::UpdatePositionLabel( const unsigned int curpos )
 void guPlayerPanel::SetFormatLabel( const wxString &format )
 {
     //guLogDebug( wxT( "SetFormatLabel( %s )" ), format.c_str() );
-    m_FormatLabel->SetLabel( wxString::Format( wxT( "[%s]" ), format.c_str() ) );
+    if (m_MediaSong.m_Format.Length() > 0 )
+    {
+        m_FormatLabel->Show();
+        m_FormatLabel->SetLabel( wxString::Format( wxT( "[%s]" ), format.c_str() ) );
+    }
+    else
+        m_FormatLabel->Hide();
     m_BitRateSizer->Layout();
 }
 


### PR DESCRIPTION
UI shows empty [] if file format is not set on the track object, e.g. when starting guayadeque with a previously stored 'nowplaying' playlist (which does not contain the format) or when playing an internet radio.

This PR stores file formats in the nowplaying playlist in guayadeque.conf and also hides the UI element if the format happens to be unset (e.g. when streaming an internet radio) [note: how to detect file format in guayadeque while playing?]