### PR TITLE
fix GCC 10 error: extended character ¡ is not valid in an identifier

### DIFF
--- a/src/ui/jamendo/Jamendo.cpp
+++ b/src/ui/jamendo/Jamendo.cpp
@@ -505,7 +505,7 @@ guJamendoUpdateThread::~guJamendoUpdateThread()
         <Albums>
             <album>
                 <id>19831</id>
-                <name>!Ya Estoy Harto de Mis Profesores¡¡¡¡¡¡¡(DEMO VERSION)</name>
+                <name>!Ya Estoy Harto de Mis Profesores(DEMO VERSION)</name>
                 <url>http://www.jamendo.com/album/19831</url>
                 <releasedate>2008-02-29T15:29:52+01:00</releasedate>
                 <filename>0 20 - !Ya Estoy Harto de Mis Profesores DEMO VERSION</filename>


### PR DESCRIPTION
This bug happens when compiling with gcc version 10. The build aborts
like this:

```
[ 40%] Building CXX object src/CMakeFiles/guayadeque.dir/ui/jamendo/Jamendo.cpp.o
/home/strubbl/.cache/pikaur/build/guayadeque-git/src/guayadeque/src/ui/jamendo/Jamendo.cpp:508:46: error: extended character ¡ is not valid in an identifier
  508 |                 <name>!Ya Estoy Harto de Mis Profesores¡¡¡¡¡¡¡(DEMO VERSION)</name>
      |                                              ^
/home/strubbl/.cache/pikaur/build/guayadeque-git/src/guayadeque/src/ui/jamendo/Jamendo.cpp:508:46: error: extended character ¡ is not valid in an identifier
/home/strubbl/.cache/pikaur/build/guayadeque-git/src/guayadeque/src/ui/jamendo/Jamendo.cpp:508:46: error: extended character ¡ is not valid in an identifier
/home/strubbl/.cache/pikaur/build/guayadeque-git/src/guayadeque/src/ui/jamendo/Jamendo.cpp:508:46: error: extended character ¡ is not valid in an identifier
/home/strubbl/.cache/pikaur/build/guayadeque-git/src/guayadeque/src/ui/jamendo/Jamendo.cpp:508:46: error: extended character ¡ is not valid in an identifier
/home/strubbl/.cache/pikaur/build/guayadeque-git/src/guayadeque/src/ui/jamendo/Jamendo.cpp:508:46: error: extended character ¡ is not valid in an identifier
/home/strubbl/.cache/pikaur/build/guayadeque-git/src/guayadeque/src/ui/jamendo/Jamendo.cpp:508:46: error: extended character ¡ is not valid in an identifier
make[2]: *** [src/CMakeFiles/guayadeque.dir/build.make:902: src/CMakeFiles/guayadeque.dir/ui/jamendo/Jamendo.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:804: src/CMakeFiles/guayadeque.dir/all] Error 2
make: *** [Makefile:150: all] Error 2
```