### PR TITLE
Get supported media types from gstreamer to avoid hardcoding extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ for the icon and splash designed for guayadeque.
 
 ---
 
-# Extra audio playback support
+## Extra audio playback support
 
 Various formats support (like `DSD/DSF`) requires ``gstreamer1.0-libav`` package:
 

--- a/po/de/guayadeque.po
+++ b/po/de/guayadeque.po
@@ -1360,10 +1360,6 @@ msgstr "TTA-Dateien"
 msgid "mpc files"
 msgstr "MPC-Dateien"
 
-#: ImportFiles.cpp:241
-msgid "dsd files"
-msgstr "DSD-Dateien"
-
 #: ImportFiles.cpp:317 MediaViewer.cpp:1363 MediaViewer.cpp:1382
 #: MediaViewer.cpp:1397 Preferences.cpp:947
 msgid "track"

--- a/po/it/guayadeque.po
+++ b/po/it/guayadeque.po
@@ -1357,10 +1357,6 @@ msgstr "file tta"
 msgid "mpc files"
 msgstr "file mpc"
 
-#: ImportFiles.cpp:241
-msgid "dsd files"
-msgstr "file dsd"
-
 #: ImportFiles.cpp:317 MediaViewer.cpp:1363 MediaViewer.cpp:1382
 #: MediaViewer.cpp:1397 Preferences.cpp:947
 msgid "track"

--- a/po/nl/guayadeque.po
+++ b/po/nl/guayadeque.po
@@ -1357,10 +1357,6 @@ msgstr "TTA-bestanden"
 msgid "mpc files"
 msgstr "MPC-bestanden"
 
-#: ImportFiles.cpp:241
-msgid "dsd files"
-msgstr "DSD-bestanden"
-
 #: ImportFiles.cpp:317 MediaViewer.cpp:1363 MediaViewer.cpp:1382
 #: MediaViewer.cpp:1397 Preferences.cpp:947
 msgid "track"

--- a/po/pl/guayadeque.po
+++ b/po/pl/guayadeque.po
@@ -1360,10 +1360,6 @@ msgstr "pliki tta"
 msgid "mpc files"
 msgstr "pliki mpc"
 
-#: ImportFiles.cpp:241
-msgid "dsd files"
-msgstr "pliki dsd"
-
 #: ImportFiles.cpp:317 MediaViewer.cpp:1363 MediaViewer.cpp:1382
 #: MediaViewer.cpp:1397 Preferences.cpp:947
 msgid "track"

--- a/src/audio/GstTypeFinder.cpp
+++ b/src/audio/GstTypeFinder.cpp
@@ -63,8 +63,8 @@ bool guGstTypeFinder::FetchMedia( void )
             const gchar *const *extensions;
             factory = GST_TYPE_FIND_FACTORY( p_feature );
             wxArrayString t_value;
-                    extensions = gst_type_find_factory_get_extensions( factory );
-                    if( extensions != NULL )
+            extensions = gst_type_find_factory_get_extensions( factory );
+            if( extensions != NULL )
                 for( guint i = 0; extensions[i]; i++ )
                 {
                     wxString ext = extensions[i];

--- a/src/audio/GstTypeFinder.cpp
+++ b/src/audio/GstTypeFinder.cpp
@@ -1,0 +1,231 @@
+
+#include "GstTypeFinder.h"
+
+namespace Guayadeque {
+
+// -------------------------------------------------------------------------------- //
+// guMediaFileExtensions
+// -------------------------------------------------------------------------------- //
+guMediaFileExtensions::guMediaFileExtensions() : guMediaFileExtensionsHashMap()
+{
+    // do nothing
+}
+
+// -------------------------------------------------------------------------------- //
+void guMediaFileExtensions::join(guMediaFileExtensions what)
+{
+    guMediaFileExtensions::iterator it;
+    for( it = what.begin(); it != what.end(); ++it )
+    {
+        wxString key = it->first;
+        wxArrayString arr = it->second;
+        wxArrayString * myptr = &( this->operator[]( key ) );
+        for( size_t i=0; i<arr.Count(); i++ )
+        {
+            wxString larri = arr[i].Lower();
+            if( myptr->Index( larri ) == wxNOT_FOUND )
+                myptr->Add( larri );
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------- //
+// guGstTypeFinder
+// -------------------------------------------------------------------------------- //
+guGstTypeFinder::guGstTypeFinder()
+{
+    FetchMedia();
+}
+
+
+// -------------------------------------------------------------------------------- //
+bool guGstTypeFinder::FetchMedia( void )
+{
+    
+    if( READY )
+        return true;
+
+    if( !gst_is_initialized() )
+        return false;
+
+    m_MediaMutex.Lock();
+
+    GList *iter, *plugin_features = gst_registry_get_feature_list(
+            gst_registry_get(),
+            GST_TYPE_TYPE_FIND_FACTORY );
+
+    for( iter=plugin_features; iter != NULL; iter=iter->next )
+    {
+        if( iter->data != NULL )
+        {
+            GstPluginFeature *p_feature = GST_PLUGIN_FEATURE( iter->data );
+            GstTypeFindFactory *factory;
+            const gchar *const *extensions;
+            factory = GST_TYPE_FIND_FACTORY( p_feature );
+            wxArrayString t_value;
+                    extensions = gst_type_find_factory_get_extensions( factory );
+                    if( extensions != NULL )
+                for( guint i = 0; extensions[i]; i++ )
+                {
+                    wxString ext = extensions[i];
+                    t_value.Add( ext.Lower() );
+                }
+            wxString t_name = gst_plugin_feature_get_name( p_feature );
+            m_Media[ t_name.Lower() ] = t_value;
+        }
+    }
+    gst_plugin_feature_list_free(plugin_features);
+    READY = !m_Media.empty();
+    if( READY )
+        InitMediaTypes();
+    m_MediaMutex.Unlock();
+    return READY;
+}
+
+// -------------------------------------------------------------------------------- //
+guMediaFileExtensions guGstTypeFinder::GetMediaByPrefix( const wxString& media_type_prefix )
+{
+    FetchMedia();
+    guMediaFileExtensions res;
+    guMediaFileExtensions::iterator it;
+    for( it = m_Media.begin(); it != m_Media.end(); ++it )
+    {
+        wxString key = it->first;
+
+        if( media_type_prefix.IsNull() || key.StartsWith( media_type_prefix ) )
+            res[key] = it->second;
+    }
+    return res;
+}
+
+// -------------------------------------------------------------------------------- //
+guMediaFileExtensions guGstTypeFinder::GetMedia( void )
+{
+    guMediaFileExtensions res;
+    for( size_t i = 0; i<m_MediaTypePrefixes.Count(); ++i )
+        res.join( GetMediaByPrefix( m_MediaTypePrefixes[i] ) );
+    return res;
+}
+
+// -------------------------------------------------------------------------------- //
+wxArrayString guGstTypeFinder::GetMediaTypes( void )
+{
+    wxArrayString res;
+    for( size_t i = 0; i<m_MediaTypePrefixes.Count(); ++i )
+    {
+        wxArrayString sub = GetMediaTypesByPrefix(m_MediaTypePrefixes[i]);
+        for( size_t j = 0; j<sub.Count(); ++j )
+            res.Add(sub[j]);
+
+    }
+    return res;
+}
+
+// -------------------------------------------------------------------------------- //
+wxArrayString guGstTypeFinder::GetMediaTypesByPrefix( const wxString &media_type_prefix )
+{
+    wxArrayString res;
+    guMediaFileExtensions med = GetMediaByPrefix(media_type_prefix);
+    guMediaFileExtensions::iterator it;
+    for( it = med.begin(); it != med.end(); ++it )
+        res.Add(it->first);
+    return res;
+}
+
+// -------------------------------------------------------------------------------- //
+wxArrayString guGstTypeFinder::GetExtensions( void )
+{
+    wxArrayString res;
+    for( size_t i = 0; i<m_MediaTypePrefixes.Count(); ++i )
+    {
+        wxArrayString sub = GetExtensionsByPrefix(m_MediaTypePrefixes[i]);
+        for( size_t j = 0; j<sub.Count(); ++j )
+            res.Add(sub[j]);
+
+    }
+    return res;
+}
+
+// -------------------------------------------------------------------------------- //
+wxArrayString guGstTypeFinder::GetExtensionsByPrefix( const wxString &media_type_prefix )
+{
+    FetchMedia();
+    wxArrayString res;
+    guMediaFileExtensions med = GetMediaByPrefix(media_type_prefix);
+    guMediaFileExtensions::iterator it;
+    for( it = med.begin(); it != med.end(); ++it )
+    {
+        wxArrayString arr = it->second;
+        for( size_t i = 0; i<arr.Count(); i++)
+            res.Add(arr[i]);
+    }
+    return res;
+}
+
+// -------------------------------------------------------------------------------- //
+void guGstTypeFinder::AddMediaTypePrefix( const wxString &media_type_prefix )
+{
+    if( m_MediaTypePrefixes.Index( media_type_prefix ) == wxNOT_FOUND )
+        m_MediaTypePrefixes.Add(media_type_prefix);
+}
+
+// -------------------------------------------------------------------------------- //
+bool guGstTypeFinder::HasPrefixes( void )
+{
+    return m_MediaTypePrefixes.Count() > 0;
+}
+
+void guGstTypeFinder::AddMediaExtension( const wxString &media_type, const wxString &extension )
+{
+    AddMediaTypePrefix(media_type);
+    if( m_Media.count( media_type ) )
+        m_Media[ media_type ].Add( extension );
+    else
+    {
+        wxArrayString addme;
+        addme.Add(extension);
+        m_Media[ media_type ] = addme;
+    }
+}
+
+
+void guGstTypeFinder::InitMediaTypes( void )
+{
+
+    // supported media types
+    //
+    AddMediaTypePrefix( "audio/" ); // all gstreamer audio
+    AddMediaTypePrefix( "video/" ); // all gstreamer video
+    AddMediaTypePrefix( "avtype_" ); // additional gstreamer formats from libav
+    AddMediaTypePrefix( "application/mxf" ); // Material Exchange Format
+    AddMediaTypePrefix( "application/ogg" ); // OGG formats
+    AddMediaTypePrefix( "application/sdp" ); // SDP mediastream file
+    AddMediaTypePrefix( "application/smil" ); // Synchronized Multimedia Integration Language
+    AddMediaTypePrefix( "application/vnd.rn-realmedia" ); // RealMedia
+    AddMediaTypePrefix( "application/x-pn-realaudio" ); // RealAudio
+    AddMediaTypePrefix( "application/x-3gp" ); // 3GP video
+    AddMediaTypePrefix( "application/x-ape" ); // APE
+    AddMediaTypePrefix( "application/x-hls" ); // UTF8 M3U
+    AddMediaTypePrefix( "application/x-ogm-audio" ); // sounds like something with sound :) 
+    AddMediaTypePrefix( "application/x-yuv4mpeg" ); // sounds like something with sound :)
+
+    // some gstreamer supported formats (DSD & exotic tracker audio)
+    // are not listed as GST_TYPE_FIND_FACTORY for some reason
+    // but those are tested to work with gstreamer-libav 1.16.2
+    //
+    AddMediaExtension( "application/x-gst-av-dsf",  "dsf" ); // DSD
+    AddMediaExtension( "application/x-gst-av-iff", "maud"  ); // Amiga MAUD audio format
+    AddMediaExtension( "audio/x-ay",  "emul" ); // AY Emul
+    AddMediaExtension( "audio/x-mod",  "mmd1" ); // OctaMED MMD1
+    AddMediaExtension( "audio/x-mod", "mptm" ); // OpenMPT
+    AddMediaExtension( "audio/x-mod", "okta" ); // Oktalyzer
+    AddMediaExtension( "audio/x-sid", "psid" ); // PlaySID
+    AddMediaExtension( "audio/x-svx", "8svx" ); // 8-Bit Sampled Voice
+    AddMediaExtension( "audio/x-vgm", "vgz"  ); // Video Game Music - Sega Megadrive (somtimes only after gunzip)
+
+}
+
+}
+
+// the end :)
+

--- a/src/audio/GstTypeFinder.h
+++ b/src/audio/GstTypeFinder.h
@@ -1,0 +1,69 @@
+
+#ifndef __GSTTYPEFINDER_H__
+#define __GSTTYPEFINDER_H__
+
+#include <gst/gst.h>
+
+#include <wx/string.h>
+#include <wx/arrstr.h>
+#include <wx/thread.h>
+#include <wx/hashmap.h>
+
+
+namespace Guayadeque {
+
+WX_DECLARE_STRING_HASH_MAP( wxArrayString, guMediaFileExtensionsHashMap );
+
+//
+// hashmap to keep stuff
+//
+class guMediaFileExtensions : public guMediaFileExtensionsHashMap
+{
+public:
+	guMediaFileExtensions();
+	void join(guMediaFileExtensions what);	
+};
+
+//
+// lazy & safe singleton object with some mutex-based sync
+// ...otherwise gstreamer crashes the player on me  :}
+//
+class guGstTypeFinder
+{
+private:
+	guGstTypeFinder();
+	guGstTypeFinder(guGstTypeFinder const &copy);
+	guGstTypeFinder& operator=(guGstTypeFinder const &copy);
+
+protected:
+	
+	guMediaFileExtensions	m_Media;
+	wxMutex			m_MediaMutex;
+
+	wxArrayString		m_MediaTypePrefixes;
+
+	bool 			READY = false;
+	
+	void AddMediaExtension( const wxString &media_type, const wxString &extension = wxEmptyString );
+	bool FetchMedia( void );
+	void InitMediaTypes( void );
+	guMediaFileExtensions GetMediaByPrefix( const wxString &media_type_prefix = wxEmptyString );
+	wxArrayString GetExtensionsByPrefix( const wxString &media_type_prefix = wxEmptyString );	
+	wxArrayString GetMediaTypesByPrefix( const wxString &media_type_prefix = wxEmptyString );
+	void AddMediaTypePrefix( const wxString &media_type_prefix );
+
+public:
+
+	static guGstTypeFinder& getGTF() { static guGstTypeFinder inst; return inst; }
+	
+	bool HasPrefixes( void );
+
+	wxArrayString GetExtensions( void );
+	wxArrayString GetMediaTypes( void );
+	guMediaFileExtensions GetMedia( void );	
+
+};
+
+}
+
+#endif

--- a/src/dbus/mpris2.cpp
+++ b/src/dbus/mpris2.cpp
@@ -42,7 +42,6 @@ namespace Guayadeque {
 
 const char * GUAYADEQUE_SUPPORTED_MIME_TYPES[] = {
     "application/ogg",
-    "application/x-gst-av-dsf",
     "application/x-ogg",
     "application/x-ogm-audio",
     "audio/aac",

--- a/src/dbus/mpris2.cpp
+++ b/src/dbus/mpris2.cpp
@@ -22,6 +22,7 @@
 #include "mpris2.h"
 
 #include "EventCommandIds.h"
+#include "GstTypeFinder.h"
 #include "mpris.h"
 #include "Utils.h"
 #include "MainFrame.h"
@@ -40,52 +41,34 @@ namespace Guayadeque {
 #define GUAYADEQUE_MPRIS2_INTERFACE_PLAYLISTS   "org.mpris.MediaPlayer2.Playlists"
 
 const char * GUAYADEQUE_SUPPORTED_MIME_TYPES[] = {
-   "application/ogg",
-   "application/vnd.rn-realmedia",
-   "application/x-3gp",
-   "application/x-gst-av-dsf",
-   "application/x-gst-av-iff",
-   "application/x-ogg",
-   "application/x-ogm-audio",
-   "audio/aac",
-   "audio/ape",
-   "audio/midi",
-   "audio/mp4",
-   "audio/mpc",
-   "audio/mpeg",
-   "audio/mpegurl",
-   "audio/ogg",
-   "audio/vnd.rn-realaudio",
-   "audio/vorbis",
-   "audio/x-ac3",
-   "audio/x-aiff",
-   "audio/x-amr-wb-sh",
-   "audio/x-au",
-   "audio/x-flac",
-   "audio/x-dts",
-   "audio/x-m4a",
-   "audio/x-matroska",
-   "audio/x-mp3",
-   "audio/x-mpeg",
-   "audio/x-mpegurl",
-   "audio/x-ms-wma",
-   "audio/x-musepack",
-   "audio/x-oggflac",
-   "audio/x-pn-realaudio",
-   "audio/x-scpls",
-   "audio/x-speex",
-   "audio/x-svx",
-   "audio/x-voc",
-   "audio/x-vorbis",
-   "audio/x-vorbis+ogg",
-   "audio/x-wav",
-   "video/quicktime",
-   "video/mpeg",
-   "video/webm",
-   "video/x-flv",
-   "video/x-ms-asf",
-   "video/x-msvideo",
-   "x-content/audio-player",
+    "application/ogg",
+    "application/x-gst-av-dsf",
+    "application/x-ogg",
+    "application/x-ogm-audio",
+    "audio/aac",
+    "audio/ape",
+    "audio/mp4",
+    "audio/mpc",
+    "audio/mpeg",
+    "audio/mpegurl",
+    "audio/ogg",
+    "audio/vnd.rn-realaudio",
+    "audio/vorbis",
+    "audio/x-flac",
+    "audio/x-mp3",
+    "audio/x-mpeg",
+    "audio/x-mpegurl",
+    "audio/x-ms-wma",
+    "audio/x-musepack",
+    "audio/x-oggflac",
+    "audio/x-pn-realaudio",
+    "audio/x-scpls",
+    "audio/x-speex",
+    "audio/x-vorbis",
+    "audio/x-vorbis+ogg",
+    "audio/x-wav",
+    "video/x-ms-asf",
+    "x-content/audio-player",
    NULL };
 
 const char * guMPRIS2_INTROSPECTION_XML =
@@ -198,6 +181,54 @@ const char * guMPRIS2_INTROSPECTION_XML =
 	"</node>\n";
 
 guMPRIS2 * guMPRIS2::m_MPRIS2 = NULL;
+
+char ** GUAYADEQUE_SUPPORTED_MIME_TYPES_WITH_GST = NULL;
+
+// -------------------------------------------------------------------------------- //
+const char ** guMPRIS2::GetSupportedMimeTypes( void )
+{
+
+    if( GUAYADEQUE_SUPPORTED_MIME_TYPES_WITH_GST != NULL )
+        return (const char**)GUAYADEQUE_SUPPORTED_MIME_TYPES_WITH_GST;
+
+    if( !guGstTypeFinder::getGTF().HasPrefixes() )
+        return GUAYADEQUE_SUPPORTED_MIME_TYPES;
+
+    static wxMutex mf_mutex;
+
+    mf_mutex.Lock();
+
+    int gsmt_count = 0;
+    while( GUAYADEQUE_SUPPORTED_MIME_TYPES[gsmt_count] != NULL )
+        gsmt_count++;
+
+    wxArrayString arr = guGstTypeFinder::getGTF().GetMediaTypes();
+
+    long unsigned int mime_ptr_size = 
+      sizeof(char*) * arr.Count() +
+      sizeof(char*) * gsmt_count + 
+      sizeof(char*);
+
+    char ** all_media = (char **) malloc( mime_ptr_size );
+
+    for( size_t i = 0; i < arr.Count(); ++i )
+    {
+        const char * mbstr = arr[i].mb_str();
+        all_media[i] = strdup(mbstr);
+    }
+
+    for( int i = 0; i < gsmt_count; ++i )
+    {
+        const char * etstr = GUAYADEQUE_SUPPORTED_MIME_TYPES[i];
+        all_media[ arr.Count() + i ] = strdup( etstr );
+    }
+
+    all_media[arr.Count() + gsmt_count] = NULL;
+
+    GUAYADEQUE_SUPPORTED_MIME_TYPES_WITH_GST = all_media;
+    mf_mutex.Unlock();
+    return (const char**)all_media;
+}
 
 // -------------------------------------------------------------------------------- //
 guMPRIS2::guMPRIS2( guDBusServer * server, guPlayerPanel * playerpanel, guDbLibrary * db ) : guDBusClient( server )
@@ -952,7 +983,7 @@ DBusHandlerResult guMPRIS2::HandleMessages( guDBusMessage * msg, guDBusMessage *
                             FillMetadataDetails( &dict, "DesktopEntry", DesktopPath );
                             const char * SupportedUriSchemes[] = { "file", "http", "https", "smb", "sftp", "cdda", NULL };
                             FillMetadataDetails( &dict, "SupportedUriSchemes", SupportedUriSchemes );
-                            FillMetadataDetails( &dict, "SupportedMimeTypes", GUAYADEQUE_SUPPORTED_MIME_TYPES );
+                            FillMetadataDetails( &dict, "SupportedMimeTypes", GetSupportedMimeTypes() );
 
                             dbus_message_iter_close_container( &args, &dict );
 
@@ -1196,7 +1227,7 @@ DBusHandlerResult guMPRIS2::HandleMessages( guDBusMessage * msg, guDBusMessage *
                                 }
                                 else if( !strcmp( QueryProperty, "SupportedMimeTypes" ) )
                                 {
-                                    if( AddVariant( reply->GetMessage(), DBUS_TYPE_ARRAY, &GUAYADEQUE_SUPPORTED_MIME_TYPES ) )
+                                    if( AddVariant( reply->GetMessage(), DBUS_TYPE_ARRAY, GetSupportedMimeTypes() ) )
                                     {
                                         Send( reply );
                                         Flush();

--- a/src/dbus/mpris2.h
+++ b/src/dbus/mpris2.h
@@ -60,6 +60,8 @@ class guMPRIS2 : public guDBusClient
     static void                 Set( guMPRIS2 * object ) { m_MPRIS2 = object; }
     static guMPRIS2 *           Get( void ) { return m_MPRIS2; }
 
+    const char **               GetSupportedMimeTypes( void );
+
 };
 
 }

--- a/src/ui/equalizer/Equalizer.cpp
+++ b/src/ui/equalizer/Equalizer.cpp
@@ -69,7 +69,7 @@ guEq10Band::guEq10Band( wxWindow * parent, guMediaCtrl * mediactrl ) //wxDialog(
     WindowSize.x = Config->ReadNum( CONFIG_KEY_EQUALIZER_WIDTH, 400, CONFIG_PATH_EQUALIZER );
     WindowSize.y = Config->ReadNum( CONFIG_KEY_EQUALIZER_HEIGHT, 250, CONFIG_PATH_EQUALIZER );
 
-    Create( parent, wxID_ANY, _( "Equalizer" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER );
+    Create( parent, wxID_ANY, _( "Equalizer" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX );
 
     wxFileConfig * EqConfig = new wxFileConfig( wxEmptyString, wxEmptyString, guPATH_EQUALIZERS_FILENAME );
     if( EqConfig )

--- a/src/ui/filebrowser/FileRenamer.cpp
+++ b/src/ui/filebrowser/FileRenamer.cpp
@@ -47,7 +47,7 @@ guFileRenamer::guFileRenamer( wxWindow * parent, guDbLibrary * db, const wxArray
     WindowSize.x = Config->ReadNum( CONFIG_KEY_FILE_RENAMER_SIZE_WIDTH, 500, CONFIG_PATH_FILE_RENAMER );
     WindowSize.y = Config->ReadNum( CONFIG_KEY_FILE_RENAMER_SIZE_HEIGHT, 320, CONFIG_PATH_FILE_RENAMER );
 
-    Create( parent, wxID_ANY, _( "Rename Files" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER );
+    Create( parent, wxID_ANY, _( "Rename Files" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER | wxMAXIMIZE_BOX );
 
 	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 

--- a/src/ui/labeleditor/LabelEditor.cpp
+++ b/src/ui/labeleditor/LabelEditor.cpp
@@ -55,7 +55,7 @@ guLabelEditor::guLabelEditor( wxWindow * parent, guDbLibrary * db, const wxStrin
     WindowSize.y = Config->ReadNum( CONFIG_KEY_POSITIONS_LABELEDIT_HEIGHT, 300, CONFIG_PATH_POSITIONS );
 
     //wxDialog( parent, wxID_ANY, _( "Songs Editor" ), wxDefaultPosition, wxSize( 625, 440 ), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER )
-    Create( parent, wxID_ANY, title, WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER );
+    Create( parent, wxID_ANY, title, WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER  | wxMAXIMIZE_BOX );
 
 
 	this->SetSizeHints( wxDefaultSize, wxDefaultSize );

--- a/src/ui/mediaviewer/importfiles/ImportFiles.cpp
+++ b/src/ui/mediaviewer/importfiles/ImportFiles.cpp
@@ -25,6 +25,7 @@
 #include "Images.h"
 #include "MediaViewer.h"
 #include "TagInfo.h"
+#include "GstTypeFinder.h"
 
 #include <wx/filedlg.h>
 
@@ -235,8 +236,14 @@ void guImportFiles::OnFileSelected( wxCommandEvent &event )
 // -------------------------------------------------------------------------------- //
 void guImportFiles::OnAddFilesClicked( wxCommandEvent &event )
 {
+    wxArrayString mf_exts = guGstTypeFinder::getGTF().GetExtensions();
+    wxString gst_ext_str = "";
+    for( size_t i = 0; i<mf_exts.Count(); ++i )
+        gst_ext_str = gst_ext_str + "*." + mf_exts[ i ] + ";";
+    if( gst_ext_str.Len() )
+        gst_ext_str.Truncate( gst_ext_str.Len() - 1 );
     wxFileDialog * FileDialog = new wxFileDialog( this, _( "Select files" ), wxGetHomeDir(), wxEmptyString,
-                wxString( _( "Audio files" ) ) + wxT( "|*.mp3;*.ogg;*.oga;*.flac;*.mp4;*.m4a;*.m4b;*.m4p;*.aac;*.wma;*.asf;*.ape;*.wav;*.aif;*.wv;*.tta;*.mpc;*.dsf;*.3gp;*.webm;*.ra;*.8svx;*.ac3;*.dts;*.maud;*.mp2;*.snd;*.voc;*.mpg;*.mov;*.avi;*.mkv;*.mka;*.mid;*.au;*.amr;*.aiff;*.flv|" ) +
+                wxString( _( "Audio files" ) ) + "|*.mp3;*.ogg;*.oga;*.flac;*.mp4;*.m4a;*.m4b;*.m4p;*.aac;*.wma;*.asf;*.ape;*.wav;*.aif;*.wv;*.tta;*.mpc;" + gst_ext_str + "|" +
                 wxString( _( "mp3 files" ) ) + wxT( " (*.mp3)|*.mp3|" ) +
                 wxString( _( "ogg files" ) ) + wxT( " (*.ogg;*.oga)|*.ogg;*.oga|" ) +
                 wxString( _( "flac files" ) ) + wxT( " (*.flac)|*.flac|" ) +
@@ -247,28 +254,9 @@ void guImportFiles::OnAddFilesClicked( wxCommandEvent &event )
                 wxString( _( "aif files" ) ) + wxT( " (*.aif)|*.aif|" ) +
                 wxString( _( "wv files" ) ) + wxT( " (*.wv)|*.wv|" ) +
                 wxString( _( "tta files" ) ) + wxT( " (*.tta)|*.tta|" ) +
-                wxString( _( "mpc files" ) ) + wxT( " (*.mpc)|*.mpc" ) +
-                wxString( _( "3gp files" ) ) + wxT( " (*.3gp)|*.3gp" ) +
-                wxString( _( "webm files" ) ) + wxT( " (*.webm)|*.webm" ) +
-                wxString( _( "ra files" ) ) + wxT( " (*.ra)|*.ra" ) +
-                wxString( _( "8svx files" ) ) + wxT( " (*.8svx)|*.8svx" ) +
-                wxString( _( "ac3 files" ) ) + wxT( " (*.ac3)|*.ac3" ) +
-                wxString( _( "dts files" ) ) + wxT( " (*.dts)|*.dts" ) +
-                wxString( _( "maud files" ) ) + wxT( " (*.maud)|*.maud" ) +
-                wxString( _( "mp2 files" ) ) + wxT( " (*.mp2)|*.mp2" ) +
-                wxString( _( "snd files" ) ) + wxT( " (*.snd)|*.snd" ) +
-                wxString( _( "voc files" ) ) + wxT( " (*.voc)|*.voc" ) +
-                wxString( _( "mpg files" ) ) + wxT( " (*.mpg)|*.mpg" ) +
-                wxString( _( "mov files" ) ) + wxT( " (*.mov)|*.mov" ) +
-                wxString( _( "avi files" ) ) + wxT( " (*.avi)|*.avi" ) +
-                wxString( _( "mkv files" ) ) + wxT( " (*.mkv)|*.mkv" ) +
-                wxString( _( "mka files" ) ) + wxT( " (*.mka)|*.mka" ) +
-                wxString( _( "mid files" ) ) + wxT( " (*.mid)|*.mid" ) +
-                wxString( _( "au files" ) ) + wxT( " (*.au)|*.au" ) +
-                wxString( _( "amr files" ) ) + wxT( " (*.amr)|*.amr" ) +
-                wxString( _( "aiff files" ) ) + wxT( " (*.aiff)|*.aiff" ) +
-                wxString( _( "flv files" ) ) + wxT( " (*.flv)|*.flv" ) +
-                wxString( _( "dsd files" ) ) + wxT( " (*.dsf)|*.dsf" ),
+                wxString( _( "mpc files" ) ) + wxT( " (*.mpc)|*.mpc|" ) +
+                wxString( _( "dsd files" ) ) + wxT( " (*.dsf)|*.dsf|" ) +
+                wxString( _( "other files" ) ) + "|" + gst_ext_str,
                 wxFD_OPEN|wxFD_FILE_MUST_EXIST|wxFD_MULTIPLE|wxFD_PREVIEW );
     if( FileDialog )
     {

--- a/src/ui/mediaviewer/importfiles/ImportFiles.cpp
+++ b/src/ui/mediaviewer/importfiles/ImportFiles.cpp
@@ -48,7 +48,7 @@ guImportFiles::guImportFiles( wxWindow * parent, guMediaViewer * mediaviewer, gu
     WindowSize.x = Config->ReadNum( CONFIG_KEY_IMPORT_FILES_WIDTH, 480, CONFIG_PATH_IMPORT_FILES_POSITION );
     WindowSize.y = Config->ReadNum( CONFIG_KEY_IMPORT_FILES_HEIGHT, 340, CONFIG_PATH_IMPORT_FILES_POSITION );
 
-    Create( parent, wxID_ANY, _( "Import Files" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER );
+    Create( parent, wxID_ANY, _( "Import Files" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX );
 
     CreateControls();
 }
@@ -255,7 +255,6 @@ void guImportFiles::OnAddFilesClicked( wxCommandEvent &event )
                 wxString( _( "wv files" ) ) + wxT( " (*.wv)|*.wv|" ) +
                 wxString( _( "tta files" ) ) + wxT( " (*.tta)|*.tta|" ) +
                 wxString( _( "mpc files" ) ) + wxT( " (*.mpc)|*.mpc|" ) +
-                wxString( _( "dsd files" ) ) + wxT( " (*.dsf)|*.dsf|" ) +
                 wxString( _( "other files" ) ) + "|" + gst_ext_str,
                 wxFD_OPEN|wxFD_FILE_MUST_EXIST|wxFD_MULTIPLE|wxFD_PREVIEW );
     if( FileDialog )

--- a/src/ui/mediaviewer/portablemedia/PortableMedia.cpp
+++ b/src/ui/mediaviewer/portablemedia/PortableMedia.cpp
@@ -685,7 +685,7 @@ guPortableMediaProperties::guPortableMediaProperties( wxWindow * parent, guPorta
     WindowSize.x = Config->ReadNum( CONFIG_KEY_POSITIONS_PMPROPERTIES_WIDTH, 570, CONFIG_PATH_POSITIONS );
     WindowSize.y = Config->ReadNum( CONFIG_KEY_POSITIONS_PMPROPERTIES_HEIGHT, 420, CONFIG_PATH_POSITIONS );
 
-    Create( parent, wxID_ANY, _( "Portable Media Properties" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER );
+    Create( parent, wxID_ANY, _( "Portable Media Properties" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER  | wxMAXIMIZE_BOX );
 
 	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 

--- a/src/ui/preferences/Preferences.cpp
+++ b/src/ui/preferences/Preferences.cpp
@@ -130,7 +130,7 @@ guPrefDialog::guPrefDialog( wxWindow* parent, guDbLibrary * db, int pagenum )
     WindowSize.y = m_Config->ReadNum( CONFIG_KEY_PREFERENCES_HEIGHT, 530, CONFIG_PATH_PREFERENCES );
 
     //wxDialog( parent, wxID_ANY, _( "Songs Editor" ), wxDefaultPosition, wxSize( 625, 440 ), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER )
-    Create( parent, wxID_ANY, _( "Preferences" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER );
+    Create( parent, wxID_ANY, _( "Preferences" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX );
 
     //
     m_MainLangChoices.Add( _( "Default" ) );

--- a/src/ui/radios/RadioEditor.cpp
+++ b/src/ui/radios/RadioEditor.cpp
@@ -25,7 +25,7 @@ namespace Guayadeque {
 
 // -------------------------------------------------------------------------------- //
 guRadioEditor::guRadioEditor( wxWindow* parent, const wxString& title, const wxString &name, const wxString &link ) :
-    wxDialog( parent, wxID_ANY, title, wxDefaultPosition, wxSize( 400,150 ), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER )
+    wxDialog( parent, wxID_ANY, title, wxDefaultPosition, wxSize( 400,150 ), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX )
 {
     this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 

--- a/src/ui/trackedit/TrackEdit.cpp
+++ b/src/ui/trackedit/TrackEdit.cpp
@@ -102,7 +102,7 @@ guTrackEditor::guTrackEditor( wxWindow * parent, guDbLibrary * db, guTrackArray 
     WindowSize.y = Config->ReadNum( CONFIG_KEY_POSITIONS_TRACKEDIT_HEIGHT, 440, CONFIG_PATH_POSITIONS );
 
     //wxDialog( parent, wxID_ANY, _( "Songs Editor" ), wxDefaultPosition, wxSize( 625, 440 ), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER )
-    Create( parent, wxID_ANY, _( "Songs Editor" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER );
+    Create( parent, wxID_ANY, _( "Songs Editor" ), WindowPos, WindowSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX );
 
 //  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 


### PR DESCRIPTION

Tested the formats below to work on my xubuntu 20.04.2:

`3gp 669 8svx ac3 aiff amr au avi bfstm dbm digi dmf dts dsf emul flv gbs it m4a maud mid mka mmd1 mod mov mp2 mpg mptm mtm nsf okta psid ptm ra s3m sap snd spc stm tiff vgm vgz voc webm xm`
