### PR TITLE
Added Ubuntu 22.04 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ sudo apt install libindicate-dev libgdk-pixbuf2.0-dev libtag-extras-dev libgstre
 sudo apt install libgpod-dev libjsoncpp-dev libgdk-pixbuf2.0-dev libtag-extras-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libwxsqlite3-3.0-dev libwxbase3.0-dev libtag1-dev libcurl4-gnutls-dev
 ```
 
+### Ubuntu 22.04
+
+```bash
+sudo apt install libgpod-dev libjsoncpp-dev libgdk-pixbuf2.0-dev libtag-extras-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libwxsqlite3-3.0-dev libwxbase3.0-dev libtag1-dev libcurl4-gnutls-dev libdbus-1-dev gettext
+```
+
 ---
 
 ## Build


### PR DESCRIPTION
Built Guayadeque on a fresh install of Ubuntu 22.04 using the dependencies listed for Ubuntu 20.04. I also needed to install **libdbus-1-dev** and **gettext** which were not listed. These will likely be needed for 20.04 but I was unable to download the ISO from Canonical to test with.